### PR TITLE
Phase 0B: Connect Desktop to Supabase Trust Spine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ yarn-error.*
 *.tsbuildinfo
 
 app-example
+
+# Local tooling caches
+.config/
+.local/
+
+# Environment
+.env
+.env.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "google-auth-library": "^10.5.0",
         "node-quickbooks": "^2.0.47",
         "otplib": "^13.2.1",
-        "pg": "^8.17.2",
+        "pg": "^8.18.0",
         "phosphor-react-native": "^3.0.3",
         "plaid": "^41.1.0",
         "qrcode": "^1.5.4",
@@ -121,6 +121,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3198,6 +3199,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5041,6 +5043,7 @@
     "node_modules/@react-navigation/native": {
       "version": "7.1.28",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -5552,6 +5555,7 @@
     "node_modules/@react-three/fiber": {
       "version": "9.5.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -5994,7 +5998,6 @@
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -6243,6 +6246,7 @@
     "node_modules/@types/pg": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6269,6 +6273,7 @@
     "node_modules/@types/react": {
       "version": "19.2.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6352,6 +6357,7 @@
     "node_modules/@types/three": {
       "version": "0.182.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -6433,6 +6439,7 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6704,6 +6711,7 @@
     "node_modules/@uppy/core": {
       "version": "5.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/store-default": "^5.0.0",
@@ -6929,6 +6937,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7716,6 +7725,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9777,6 +9787,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9955,6 +9966,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10220,6 +10232,7 @@
     "node_modules/expo": {
       "version": "54.0.33",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -10270,6 +10283,7 @@
     "node_modules/expo-asset": {
       "version": "12.0.12",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.12"
@@ -10307,6 +10321,7 @@
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -10319,6 +10334,7 @@
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
@@ -10327,6 +10343,7 @@
     "node_modules/expo-font": {
       "version": "14.0.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -10378,6 +10395,7 @@
     "node_modules/expo-linking": {
       "version": "8.0.11",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -11755,6 +11773,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -11826,6 +11845,7 @@
     "node_modules/immer": {
       "version": "10.2.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -12511,6 +12531,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15181,7 +15202,10 @@
     },
     "node_modules/pg": {
       "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -15872,6 +15896,7 @@
     "node_modules/react": {
       "version": "19.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16012,6 +16037,7 @@
     "node_modules/react-dom": {
       "version": "19.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -16047,6 +16073,7 @@
     "node_modules/react-hook-form": {
       "version": "7.71.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -16085,13 +16112,15 @@
     },
     "node_modules/react-is": {
       "version": "19.2.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-native": {
       "version": "0.81.4",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
       "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.4",
@@ -16149,6 +16178,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -16172,6 +16202,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -16196,6 +16227,7 @@
     "node_modules/react-native-safe-area-context": {
       "version": "5.6.2",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -16204,6 +16236,7 @@
     "node_modules/react-native-screens": {
       "version": "4.16.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -16217,6 +16250,7 @@
     "node_modules/react-native-svg": {
       "version": "15.15.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -16232,6 +16266,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -16258,6 +16293,7 @@
     "node_modules/react-native-webview": {
       "version": "13.15.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -16420,6 +16456,7 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -16441,6 +16478,7 @@
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16636,7 +16674,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -16950,7 +16989,8 @@
     },
     "node_modules/robot3": {
       "version": "1.2.0",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -17866,6 +17906,7 @@
     "node_modules/stripe": {
       "version": "20.3.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -18149,7 +18190,8 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
       "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -18198,6 +18240,7 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18514,6 +18557,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "google-auth-library": "^10.5.0",
     "node-quickbooks": "^2.0.47",
     "otplib": "^13.2.1",
-    "pg": "^8.17.2",
+    "pg": "^8.18.0",
     "phosphor-react-native": "^3.0.3",
     "plaid": "^41.1.0",
     "qrcode": "^1.5.4",

--- a/server/financeRoutes.ts
+++ b/server/financeRoutes.ts
@@ -4,6 +4,7 @@ import { sql } from 'drizzle-orm';
 import { createReceipt } from './receiptService';
 import { getConnectionsByTenant } from './financeTokenStore';
 import { computeSnapshot } from './snapshotEngine';
+import { getDefaultSuiteId, getDefaultOfficeId } from './suiteContext';
 import crypto from 'crypto';
 
 const router = Router();
@@ -59,8 +60,8 @@ const emptyChapters = () => ({
 
 router.get('/api/finance/snapshot', async (req: Request, res: Response) => {
   try {
-    const suiteId = getQueryParam(req.query.suiteId as string, 'default');
-    const officeId = getQueryParam(req.query.officeId as string, 'default');
+    const suiteId = getQueryParam(req.query.suiteId as string, getDefaultSuiteId());
+    const officeId = getQueryParam(req.query.officeId as string, getDefaultOfficeId());
 
     const snapshotResult = await db.execute(sql`
       SELECT id, suite_id, office_id, generated_at, chapter_now, chapter_next, chapter_month,
@@ -118,8 +119,8 @@ router.get('/api/finance/snapshot', async (req: Request, res: Response) => {
 
 router.get('/api/finance/timeline', async (req: Request, res: Response) => {
   try {
-    const suiteId = getQueryParam(req.query.suiteId as string, 'default');
-    const officeId = getQueryParam(req.query.officeId as string, 'default');
+    const suiteId = getQueryParam(req.query.suiteId as string, getDefaultSuiteId());
+    const officeId = getQueryParam(req.query.officeId as string, getDefaultOfficeId());
     const range = getQueryParam(req.query.range as string, '30d');
     const limit = Math.min(parseInt(getQueryParam(req.query.limit as string, '50'), 10) || 50, 200);
     const offset = parseInt(getQueryParam(req.query.offset as string, '0'), 10) || 0;
@@ -166,8 +167,8 @@ router.get('/api/finance/timeline', async (req: Request, res: Response) => {
 
 router.get('/api/finance/explain', async (req: Request, res: Response) => {
   try {
-    const suiteId = getQueryParam(req.query.suiteId as string, 'default');
-    const officeId = getQueryParam(req.query.officeId as string, 'default');
+    const suiteId = getQueryParam(req.query.suiteId as string, getDefaultSuiteId());
+    const officeId = getQueryParam(req.query.officeId as string, getDefaultOfficeId());
     const metricId = getQueryParam(req.query.metricId as string, '');
 
     if (!metricId) {
@@ -223,8 +224,8 @@ router.get('/api/finance/explain', async (req: Request, res: Response) => {
 
 router.get('/api/connections/status', async (req: Request, res: Response) => {
   try {
-    const suiteId = getQueryParam(req.query.suiteId as string, 'default');
-    const officeId = getQueryParam(req.query.officeId as string, 'default');
+    const suiteId = getQueryParam(req.query.suiteId as string, getDefaultSuiteId());
+    const officeId = getQueryParam(req.query.officeId as string, getDefaultOfficeId());
 
     const connections = await getConnectionsByTenant(suiteId, officeId);
 
@@ -263,8 +264,8 @@ router.get('/api/connections/status', async (req: Request, res: Response) => {
 
 router.get('/api/finance/lifecycle', async (req: Request, res: Response) => {
   try {
-    const suiteId = getQueryParam(req.query.suiteId as string, 'default');
-    const officeId = getQueryParam(req.query.officeId as string, 'default');
+    const suiteId = getQueryParam(req.query.suiteId as string, getDefaultSuiteId());
+    const officeId = getQueryParam(req.query.officeId as string, getDefaultOfficeId());
     const entityId = getQueryParam(req.query.entityId as string, '');
 
     let result;
@@ -347,7 +348,7 @@ router.get('/api/finance/lifecycle', async (req: Request, res: Response) => {
 
 router.post('/api/finance/compute-snapshot', async (req: Request, res: Response) => {
   try {
-    const { suiteId = 'default', officeId = 'default' } = req.body;
+    const { suiteId = getDefaultSuiteId(), officeId = getDefaultOfficeId() } = req.body;
     const snapshot = await computeSnapshot(suiteId, officeId);
     res.json(snapshot);
   } catch (error: any) {
@@ -358,7 +359,7 @@ router.post('/api/finance/compute-snapshot', async (req: Request, res: Response)
 
 router.post('/api/finance/proposals', async (req: Request, res: Response) => {
   try {
-    const { suiteId = 'default', officeId = 'default', title, type, description, predictedImpact, dependencies } = req.body;
+    const { suiteId = getDefaultSuiteId(), officeId = getDefaultOfficeId(), title, type, description, predictedImpact, dependencies } = req.body;
 
     if (!title || !type) {
       return res.status(400).json({ error: 'title and type are required' });
@@ -410,7 +411,7 @@ router.post('/api/finance/proposals', async (req: Request, res: Response) => {
 
 router.post('/api/finance/actions/execute', async (req: Request, res: Response) => {
   try {
-    const { suiteId = 'default', officeId = 'default', proposalId, approvedBy } = req.body;
+    const { suiteId = getDefaultSuiteId(), officeId = getDefaultOfficeId(), proposalId, approvedBy } = req.body;
 
     if (!proposalId || !approvedBy) {
       return res.status(400).json({ error: 'proposalId and approvedBy are required' });

--- a/server/plaidWebhookHandler.ts
+++ b/server/plaidWebhookHandler.ts
@@ -4,6 +4,7 @@ import { db } from './db';
 import { sql } from 'drizzle-orm';
 import { createReceipt } from './receiptService';
 import { updateConnectionSyncTime } from './financeTokenStore';
+import { getDefaultSuiteId, getDefaultOfficeId } from './suiteContext';
 import crypto from 'crypto';
 
 const configuration = new Configuration({
@@ -17,9 +18,6 @@ const configuration = new Configuration({
 });
 
 const plaidClient = new PlaidApi(configuration);
-
-const DEFAULT_SUITE_ID = 'default';
-const DEFAULT_OFFICE_ID = 'default';
 
 const PLAID_EVENT_MAP: Record<string, string> = {
   'TRANSACTIONS.DEFAULT_UPDATE': 'bank_tx_posted',
@@ -430,8 +428,8 @@ router.post('/api/plaid/finance-webhook', async (req: Request, res: Response) =>
     }
 
     const connection = await findConnectionByItemId(itemId);
-    const suiteId = connection?.suiteId || DEFAULT_SUITE_ID;
-    const officeId = connection?.officeId || DEFAULT_OFFICE_ID;
+    const suiteId = connection?.suiteId || getDefaultSuiteId();
+    const officeId = connection?.officeId || getDefaultOfficeId();
     const connectionId = connection?.id || null;
 
     const timestamp = new Date().toISOString();

--- a/server/seed.ts
+++ b/server/seed.ts
@@ -4,45 +4,64 @@ import { sql } from 'drizzle-orm';
 async function seed() {
   console.log('Seeding database...');
 
-  const demoUserId = '00000000-0000-0000-0000-000000000001';
-  
+  // Create demo suite via Trust Spine's ensure_suite function
+  const suiteResult = await db.execute(sql`
+    SELECT app.ensure_suite('demo-tenant', 'Zenith Solutions') AS suite_id
+  `);
+  const rows = (suiteResult.rows || suiteResult) as any[];
+  const demoSuiteId = rows[0].suite_id;
+  console.log(`Demo suite created: ${demoSuiteId}`);
+
+  // Create demo office
   await db.execute(sql`
-    INSERT INTO users (id, email, name, business_name, booking_slug)
-    VALUES (${demoUserId}, 'demo@zenith.com', 'Scott Thompson', 'Zenith Solutions', 'zenith-solutions')
-    ON CONFLICT (id) DO UPDATE SET 
+    INSERT INTO app.offices (suite_id, label)
+    VALUES (${demoSuiteId}, 'Main Office')
+    ON CONFLICT DO NOTHING
+  `);
+  console.log('Demo office created');
+
+  // Create suite profile (business profile)
+  await db.execute(sql`
+    INSERT INTO suite_profiles (suite_id, email, name, business_name, booking_slug)
+    VALUES (${demoSuiteId}, 'demo@zenith.com', 'Scott Thompson', 'Zenith Solutions', 'zenith-solutions')
+    ON CONFLICT (suite_id) DO UPDATE SET
       email = EXCLUDED.email,
       name = EXCLUDED.name,
       business_name = EXCLUDED.business_name,
       booking_slug = EXCLUDED.booking_slug
   `);
-  console.log('Created demo user');
+  console.log('Created demo suite profile');
 
+  // Create demo services
   await db.execute(sql`
-    INSERT INTO services (id, user_id, name, description, duration, price, currency, color, is_active)
-    VALUES 
-      ('10000000-0000-0000-0000-000000000001', ${demoUserId}, 'Strategy Consultation', 'Deep dive into your business strategy and growth opportunities', 60, 15000, 'usd', '#4facfe', true),
-      ('10000000-0000-0000-0000-000000000002', ${demoUserId}, 'Quick Call', 'Short check-in or quick question session', 15, 0, 'usd', '#34c759', true),
-      ('10000000-0000-0000-0000-000000000003', ${demoUserId}, 'Operations Review', 'Review your current operations and identify improvements', 45, 10000, 'usd', '#f59e0b', true)
+    INSERT INTO services (id, suite_id, name, description, duration, price, currency, color, is_active)
+    VALUES
+      ('10000000-0000-0000-0000-000000000001', ${demoSuiteId}, 'Strategy Consultation', 'Deep dive into your business strategy and growth opportunities', 60, 15000, 'usd', '#4facfe', true),
+      ('10000000-0000-0000-0000-000000000002', ${demoSuiteId}, 'Quick Call', 'Short check-in or quick question session', 15, 0, 'usd', '#34c759', true),
+      ('10000000-0000-0000-0000-000000000003', ${demoSuiteId}, 'Operations Review', 'Review your current operations and identify improvements', 45, 10000, 'usd', '#f59e0b', true)
     ON CONFLICT (id) DO NOTHING
   `);
   console.log('Created demo services');
 
+  // Set RLS context for availability and buffer_settings inserts
+  await db.execute(sql`SELECT set_config('app.current_suite_id', ${demoSuiteId}, true)`);
+
   await db.execute(sql`
-    INSERT INTO availability (id, user_id, day_of_week, start_time, end_time, is_active)
-    VALUES 
-      ('20000000-0000-0000-0000-000000000001', ${demoUserId}, 1, '09:00', '17:00', true),
-      ('20000000-0000-0000-0000-000000000002', ${demoUserId}, 2, '09:00', '17:00', true),
-      ('20000000-0000-0000-0000-000000000003', ${demoUserId}, 3, '09:00', '17:00', true),
-      ('20000000-0000-0000-0000-000000000004', ${demoUserId}, 4, '09:00', '17:00', true),
-      ('20000000-0000-0000-0000-000000000005', ${demoUserId}, 5, '09:00', '12:00', true)
+    INSERT INTO availability (id, suite_id, day_of_week, start_time, end_time, is_active)
+    VALUES
+      ('20000000-0000-0000-0000-000000000001', ${demoSuiteId}, 1, '09:00', '17:00', true),
+      ('20000000-0000-0000-0000-000000000002', ${demoSuiteId}, 2, '09:00', '17:00', true),
+      ('20000000-0000-0000-0000-000000000003', ${demoSuiteId}, 3, '09:00', '17:00', true),
+      ('20000000-0000-0000-0000-000000000004', ${demoSuiteId}, 4, '09:00', '17:00', true),
+      ('20000000-0000-0000-0000-000000000005', ${demoSuiteId}, 5, '09:00', '12:00', true)
     ON CONFLICT (id) DO NOTHING
   `);
   console.log('Created demo availability');
 
   await db.execute(sql`
-    INSERT INTO buffer_settings (id, user_id, before_buffer, after_buffer, minimum_notice, max_advance_booking)
-    VALUES ('30000000-0000-0000-0000-000000000001', ${demoUserId}, 0, 15, 60, 30)
-    ON CONFLICT (user_id) DO NOTHING
+    INSERT INTO buffer_settings (id, suite_id, before_buffer, after_buffer, minimum_notice, max_advance_booking)
+    VALUES ('30000000-0000-0000-0000-000000000001', ${demoSuiteId}, 0, 15, 60, 30)
+    ON CONFLICT (suite_id) DO NOTHING
   `);
   console.log('Created buffer settings');
 

--- a/server/suiteContext.ts
+++ b/server/suiteContext.ts
@@ -1,0 +1,21 @@
+// Shared suite/office context — set at startup, used by all modules
+// This avoids circular dependencies between index.ts and other modules
+
+let _defaultSuiteId = '';
+let _defaultOfficeId = '';
+
+export function setDefaultSuiteId(id: string) {
+  _defaultSuiteId = id;
+}
+
+export function setDefaultOfficeId(id: string) {
+  _defaultOfficeId = id;
+}
+
+export function getDefaultSuiteId(): string {
+  return _defaultSuiteId;
+}
+
+export function getDefaultOfficeId(): string {
+  return _defaultOfficeId;
+}


### PR DESCRIPTION
## Summary

- **Remove `initDatabase()`** — 13 runtime-created tables replaced by 49 Supabase Trust Spine migrations + 12 desktop tables with RLS
- **Upgrade receipts** from 8-column desktop format to 15-column Trust Spine format (hash chain, correlation_id, actor tracking)
- **Convert identity** from TEXT suite_id to UUID with FK to `app.suites`/`app.offices`
- **Add RLS context middleware** — sets `app.current_suite_id` per request, positioned before all webhook routes
- **Security hardening** — fail-closed TOKEN_ENCRYPTION_KEY, Gusto webhook secret redacted, no header injection

## Supabase Backend (already deployed)

| Item | Status |
|------|--------|
| 49 Trust Spine + A2A migrations | Applied |
| 12 desktop tables with RLS + FORCE | Applied |
| 5 Edge Functions | Deployed |
| Splinter lint | 0 WARNs, 0 ERRORs |
| 40 tables with RLS + FORCE | Verified |

## Railway Environment

| Variable | Status |
|----------|--------|
| DATABASE_URL (Session Pooler) | Set |
| SUPABASE_URL | Set |
| SUPABASE_ANON_KEY | Set |
| TOKEN_ENCRYPTION_KEY | Set |

## Security Review

- [x] No hardcoded secrets/credentials
- [x] No PII/token values in console.log
- [x] RLS middleware before all routes
- [x] TOKEN_ENCRYPTION_KEY fails closed (Law #3)
- [x] Webhook secrets validated, not logged (Law #9)
- [x] Parameterized SQL queries throughout (drizzle sql tagged template)
- [x] TypeScript server compiles with 0 errors

## Aspire Laws Compliance

| Law | Status |
|-----|--------|
| #2 Receipt for All | 15-column Trust Spine format |
| #3 Fail Closed | TOKEN_ENCRYPTION_KEY, missing DB = deny |
| #6 Tenant Isolation | RLS + FORCE on all 40 tables |
| #9 Security Baselines | Secrets redacted, no PII logged |

## Test Plan

- [ ] Railway auto-deploys from merge
- [ ] Health check: `GET https://www.aspireos.app/api/health`
- [ ] Finance routes respond (Stripe, Plaid, Gusto, QuickBooks)
- [ ] Receipts written in Trust Spine format
- [ ] RLS isolation: cross-tenant query returns 0 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)