### PR TITLE
fix(adam): send details as clean string to /v1/agents/invoke

### DIFF
--- a/server/serviceHub/property/adamResearchClient.ts
+++ b/server/serviceHub/property/adamResearchClient.ts
@@ -27,7 +27,7 @@
  *
  * Endpoint:
  *   POST {ORCHESTRATOR_URL}/v1/agents/invoke
- *   Body: { agent, task, details: { address }, suite_id, office_id, correlation_id }
+ *   Body: { agent, task, details: "<full address string>", suite_id, office_id, correlation_id }
  */
 
 import { logger } from '../../logger';
@@ -372,7 +372,7 @@ export async function fetchAdamPropertyResearch(
   const requestBody = {
     agent: AGENT_NAME,
     task: TASK_NAME,
-    details: { address: cleanAddress },
+    details: cleanAddress,
     suite_id: suiteId,
     office_id: officeId,
     correlation_id: correlationId,


### PR DESCRIPTION
## Root cause
adamResearchClient.ts sent `details: { address: cleanAddress }` (object). Backend at server.py:1656 runs `str(details).strip()`, yielding `"{'address': '...'}"` (Python dict-repr noise). That polluted string is passed to ATTOM address extraction and resolves to a bad parcel -> SuccessWithoutResult across every endpoint. End user sees empty property cards.

## Fix
One line: `details: cleanAddress` (string).

## Verification (live curl after aspire-backend PR #49)
- Object form -> SuccessWithoutResult on every ATTOM endpoint
- String form -> Full record: attom_id=37147057, 5bd/3ba/2635sqft, owner TONY LEWIS SCOTT, AVM $317,906, FHA mortgage $192,449, annual tax $4,508.14

## Risk
Minimal. Server-side client change. Backend already handles string details (well-tested ElevenLabs Ava path).