### PR TITLE
feat(estimate-studio): Tim Rail Controls tab + laptop/tablet chrome hoist

### DIFF
--- a/__tests__/visuals/tim-rail-controls.test.ts
+++ b/__tests__/visuals/tim-rail-controls.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tim Rail — Controls Tab Regression Lock
+ *
+ * These tests assert file-content invariants for the Controls tab and the
+ * laptop/tablet chrome-hoist behavior. They do NOT exercise runtime
+ * behavior — they guarantee specific anti-patterns can't sneak back into
+ * the codebase.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..');
+const read = (rel: string) =>
+  readFileSync(join(ROOT, rel.replace(/\//g, '\\')), 'utf8');
+
+describe('Tim Rail — Controls Tab', () => {
+  describe('TimRailTabSwitcher', () => {
+    const src = read(
+      'components/service-hub/estimate-studio/tim-rail/TimRailTabSwitcher.tsx',
+    );
+
+    it('declares Controls as the third tab id (replaces Activity)', () => {
+      expect(src).toMatch(
+        /TimRailTabId\s*=\s*'controls'\s*\|\s*'context'\s*\|\s*'assistant'/,
+      );
+    });
+
+    it('renders the Controls label (not Activity)', () => {
+      expect(src).toMatch(/label:\s*'Controls'/);
+      expect(src).not.toMatch(/label:\s*'Activity'/);
+    });
+  });
+
+  describe('TimRailContainer', () => {
+    const src = read(
+      'components/service-hub/estimate-studio/TimRailContainer.tsx',
+    );
+
+    it('imports TimRailControlsTab', () => {
+      expect(src).toMatch(
+        /import\s+\{\s*TimRailControlsTab\s*\}\s+from\s+'\.\/tim-rail\/TimRailControlsTab'/,
+      );
+    });
+
+    it('renders TimRailControlsTab when activeTab === controls', () => {
+      expect(src).toMatch(
+        /activeTab\s*===\s*'controls'\s*&&\s*<TimRailControlsTab\s*\/>/,
+      );
+    });
+
+    it('no longer renders ActivityPlaceholder', () => {
+      expect(src).not.toMatch(/ActivityPlaceholder/);
+    });
+  });
+
+  describe('TimRailControlsTab — section structure', () => {
+    const src = read(
+      'components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx',
+    );
+
+    it('renders three section titles: PROJECT, NAVIGATE, QUICK ACTIONS', () => {
+      expect(src).toMatch(/title="PROJECT"/);
+      expect(src).toMatch(/title="NAVIGATE"/);
+      expect(src).toMatch(/title="QUICK ACTIONS"/);
+    });
+
+    it('lists all 6 studio tabs in the NAVIGATE grid', () => {
+      const expectedTabs = [
+        'Visuals',
+        'Plans & Photos',
+        'Scope',
+        'Materials',
+        'Takeoff',
+        'Estimate',
+      ];
+      for (const label of expectedTabs) {
+        expect(src).toContain(`label: '${label}'`);
+      }
+    });
+
+    it('renders MaterialsSlotBar OR ProjectAddressBar based on pathname', () => {
+      expect(src).toMatch(/isMaterialsTab\s*\?\s*<MaterialsSlotBar/);
+      expect(src).toMatch(/:\s*<ProjectAddressBar/);
+    });
+
+    it('uses pathname.endsWith to detect Materials route (matches shell convention)', () => {
+      expect(src).toMatch(/pathname\.endsWith\('\/materials'\)/);
+    });
+
+    it('uses shared useEstimateStudioActions hook for Upload + New Project', () => {
+      expect(src).toMatch(
+        /from\s+'@\/hooks\/useEstimateStudioActions'/,
+      );
+      expect(src).toMatch(/useEstimateStudioActions\(\)/);
+    });
+
+    it('hides PROJECT + NAVIGATE on desktop (>=1280) to avoid duplicating canvas chrome', () => {
+      expect(src).toMatch(/DESKTOP_BREAKPOINT\s*=\s*1280/);
+      expect(src).toMatch(/showChromeSections/);
+    });
+
+    it('has minimum 44pt tap target on primary buttons (a11y)', () => {
+      expect(src).toMatch(/minHeight:\s*44/);
+    });
+  });
+
+  describe('EstimateStudioShell — chrome hoist', () => {
+    const src = read(
+      'components/service-hub/estimate-studio/EstimateStudioShell.tsx',
+    );
+
+    it('declares LAPTOP_OR_TABLET_BREAKPOINT = 1280', () => {
+      expect(src).toMatch(/LAPTOP_OR_TABLET_BREAKPOINT\s*=\s*1280/);
+    });
+
+    it('hides EstimateStudioHeader / slot / tab bar when isLaptopOrTablet', () => {
+      // The header + slot + tab bar must live inside a `!isLaptopOrTablet`
+      // conditional so the canvas is hero-only at laptop+tablet widths.
+      expect(src).toMatch(/\!isLaptopOrTablet\s*&&/);
+    });
+
+    it('slims outer canvas maxWidth to 880 on laptop/tablet', () => {
+      expect(src).toMatch(/isLaptopOrTablet[\s\S]{0,40}880/);
+    });
+
+    it('uses calc(100vh - 96px) on laptop/tablet (chrome-hoisted height)', () => {
+      expect(src).toMatch(/calc\(100vh - 96px\)/);
+    });
+  });
+});

--- a/components/service-hub/estimate-studio/EstimateStudioShell.tsx
+++ b/components/service-hub/estimate-studio/EstimateStudioShell.tsx
@@ -10,12 +10,17 @@ import { MaterialsSearchProvider } from './materials/MaterialsSearchContext';
 import { useProjectAddress } from '@/hooks/useProjectAddress';
 
 // Breakpoint ladder (responsive Estimate Studio):
-//   Desktop  : >= 1400  — canvas capped at 1400 + centered
-//   Laptop   : 1100–1399 — canvas full width, rail right
-//   Tablet   : 768–1099  — canvas full width, rail STACKED below
-//   Mobile   : <  768    — canvas full width, rail stacked, tighter chrome
+//   Desktop          : >= 1400  — canvas capped at 1400 + centered, full chrome
+//   Laptop/Tablet UX : 768–1279 — canvas-level chrome HOISTED into Tim Rail
+//                                 Controls tab. Canvas shows ONLY hero/photos.
+//                                 Outer canvas slimmed to maxWidth 880.
+//   Workspace        : >= 1100 (within laptop/tablet range) — rail side-by-side
+//   Stacked          : 768–1099 — rail stacked below canvas
+//   Mobile           : <  768   — chrome stays in canvas (rail tabs unusable
+//                                 at this width); tighter chrome.
 const DESKTOP_BREAKPOINT = 1400;
-const WORKSPACE_BREAKPOINT = 1100;        // Tim rail collapses below this
+const LAPTOP_OR_TABLET_BREAKPOINT = 1280;  // chrome hoist applies below this
+const WORKSPACE_BREAKPOINT = 1100;         // Tim rail stacks below this
 const TABLET_BREAKPOINT = 768;
 
 // Estimate Studio workspace — ONE BIG CANVAS.
@@ -54,28 +59,32 @@ interface EstimateStudioShellProps {
 }
 
 export function EstimateStudioShell({ children }: EstimateStudioShellProps) {
-  const { width, height } = useWindowDimensions();
+  const { width } = useWindowDimensions();
   const isDesktop = width >= DESKTOP_BREAKPOINT;
   const isWide = width >= WORKSPACE_BREAKPOINT;
   const isTablet = width < WORKSPACE_BREAKPOINT && width >= TABLET_BREAKPOINT;
   const isMobile = width < TABLET_BREAKPOINT;
-  // Laptop heuristic: wide enough for the rail (>=1100) but short viewport
-  // (<860 inner height after browser chrome). This is what makes 13–15"
-  // laptops look 'stretched out' on the same code that fits on a 1080p+
-  // desktop — fixed calc(100vh - 118px) leaves no room for the full hero
-  // photo + photo lane row, content overflows the canvas at the bottom.
-  const isLaptop = isWide && !isDesktop && height < 900;
+  // Chrome hoist: ANY width in the laptop/tablet band (768 ≤ w < 1280) moves
+  // the in-canvas chrome (header + slot + tab bar) into the Tim Rail's
+  // Controls tab. Replaces the prior height-dependent isLaptop heuristic —
+  // the user's 958×937 viewport didn't trip it because the trigger was
+  // gated on width >= 1100 AND height < 900.
+  const isLaptopOrTablet =
+    width >= TABLET_BREAKPOINT && width < LAPTOP_OR_TABLET_BREAKPOINT;
 
-  // Responsive canvas width: cap on big desktops, slim cap on laptop, full
-  // width on tablet/mobile.
-  // Laptop cap (1280) leaves a small page-bg gutter on each side so the
-  // workspace doesn't feel poster-wide on a 13–15" screen — user reported
-  // 'a little less wide'.
-  const canvasMaxWidth = isDesktop ? 1400 : isLaptop ? 1280 : undefined;
+  // Responsive canvas width:
+  //   Desktop (>=1400)        → 1400 cap
+  //   Laptop/Tablet (768..1279)→ 880 cap (slim, leaves page-bg gutter)
+  //   Mobile (<768)           → full width
+  const canvasMaxWidth = isDesktop
+    ? 1400
+    : isLaptopOrTablet
+      ? 880
+      : undefined;
 
-  // Laptop-specific dynamic height: subtract more so the canvas leaves
-  // breathing room for the photo lane at the bottom. Desktop unchanged.
-  const canvasHeightCalc = isLaptop
+  // With chrome hoisted out, the canvas reclaims the ~22px the chrome was
+  // taking, so the calc subtracts less of the viewport. Desktop unchanged.
+  const canvasHeightCalc = isLaptopOrTablet
     ? 'calc(100vh - 96px)'
     : 'calc(100vh - 118px)';
   const pathname = usePathname() ?? '';
@@ -97,7 +106,7 @@ export function EstimateStudioShell({ children }: EstimateStudioShellProps) {
         canvasMaxWidth ? { maxWidth: canvasMaxWidth } : null,
         // Laptop-specific height override (short viewports only). Desktop
         // keeps the existing calc(100vh - 118px) baked into outerCanvas.
-        Platform.OS === 'web' && isLaptop
+        Platform.OS === 'web' && isLaptopOrTablet
           ? (({
               height: canvasHeightCalc,
               maxHeight: canvasHeightCalc,
@@ -109,41 +118,41 @@ export function EstimateStudioShell({ children }: EstimateStudioShellProps) {
       <View style={[styles.row, !isWide && styles.rowStacked]}>
         {/* MAIN ZONE */}
         <View style={styles.mainZone} testID="estimate-studio-main-zone">
-          <View
-            style={[
-              styles.mainZonePadded,
-              // Laptop: compress header padding so the canvas screen +
-              // property cards get the vertical space they need.
-              isLaptop ? { paddingTop: 8, paddingBottom: 0 } : null,
-            ]}
-          >
-            <EstimateStudioHeader />
-          </View>
+          {/* Canvas-level chrome is HIDDEN on laptop + tablet — the Tim
+              Rail's Controls tab owns header/slot/tab bar there so the
+              canvas can be pure visual content. Mobile keeps it because
+              the rail isn't reachable below 768px. */}
+          {!isLaptopOrTablet && (
+            <>
+              <View style={styles.mainZonePadded}>
+                <EstimateStudioHeader />
+              </View>
 
-          {/* Contextual slot. Phase 1 default = Visuals address search. Phase 2+
-              swaps based on active tab. On Materials, the slot is hidden —
-              the Materials tab renders its own warehouse-search bar. */}
-          <View
-            style={[
-              styles.contextualSlot,
-              isLaptop ? { paddingTop: 4, paddingBottom: 4 } : null,
-            ]}
-          >
-            {isMaterialsTab ? <MaterialsSlotBar /> : <ProjectAddressBar />}
-          </View>
+              {/* Contextual slot. Phase 1 default = Visuals address search.
+                  Phase 2+ swaps based on active tab. On Materials, the
+                  slot is hidden — the Materials tab renders its own
+                  warehouse-search bar. */}
+              <View style={styles.contextualSlot}>
+                {isMaterialsTab ? <MaterialsSlotBar /> : <ProjectAddressBar />}
+              </View>
 
-          {/* Tab bar — Phase 2 */}
-          <View
-            style={[
-              styles.tabBarSlot,
-              isLaptop ? { paddingTop: 2, paddingBottom: 4 } : null,
-            ]}
-          >
-            <EstimateStudioTabBar />
-          </View>
+              {/* Tab bar — Phase 2 */}
+              <View style={styles.tabBarSlot}>
+                <EstimateStudioTabBar />
+              </View>
+            </>
+          )}
 
           {/* Active tab content (rendered via expo-router Slot in _layout.tsx). */}
-          <View style={styles.canvasArea} testID="estimate-studio-canvas-content">
+          <View
+            style={[
+              styles.canvasArea,
+              // When chrome is hoisted, the canvas has no tab-bar above it
+              // — drop the top hairline (it would float against nothing).
+              isLaptopOrTablet ? styles.canvasAreaFlush : null,
+            ]}
+            testID="estimate-studio-canvas-content"
+          >
             {children}
           </View>
         </View>
@@ -269,5 +278,11 @@ const styles = StyleSheet.create({
     borderRightWidth: 0,
     borderBottomWidth: 0,
     overflow: 'hidden',
+  },
+  // Chrome-hoisted variant: no chrome above the canvas, so drop the
+  // top hairline that would otherwise float against the bare gutter.
+  canvasAreaFlush: {
+    borderTopWidth: 0,
+    backgroundColor: 'transparent',
   },
 });

--- a/components/service-hub/estimate-studio/TimRailContainer.tsx
+++ b/components/service-hub/estimate-studio/TimRailContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import {
   TimRailTabSwitcher,
   type TimRailTabId,
@@ -9,12 +9,14 @@ import { TimRailChatStub } from './tim-rail/TimRailChatStub';
 import { TimRailFileDrop } from './tim-rail/TimRailFileDrop';
 import { TimRailVoiceButton } from './tim-rail/TimRailVoiceButton';
 import { TimRailContextTab } from './tim-rail/TimRailContextTab';
+import { TimRailControlsTab } from './tim-rail/TimRailControlsTab';
 import { useProjectAddress } from '@/hooks/useProjectAddress';
 import { usePropertyData } from '@/hooks/usePropertyData';
 
-// Pass 3.2 wires the tab switcher to actually swap content. Pass 3.3 will
-// replace the Activity placeholder with a real activity stream and replace
-// the chat stub with the property-aware Tim assistant.
+// Tim Rail tabs: Assistant | Context | Controls.
+// The Controls tab owns the studio chrome (address bar + studio tabs +
+// quick actions) on laptops + tablets — see TimRailControlsTab.tsx and
+// EstimateStudioShell.tsx for the chrome-hoist behavior.
 //
 // Aspire Law #1 + #7: this rail is a render layer; no autonomous decisions
 // or state mutations beyond UI state.
@@ -33,7 +35,7 @@ export function TimRailContainer() {
         {activeTab === 'context' && (
           <TimRailContextTab data={propertyData.data} status={propertyData.status} />
         )}
-        {activeTab === 'activity' && <ActivityPlaceholder />}
+        {activeTab === 'controls' && <TimRailControlsTab />}
       </View>
       {/* File drop + voice composer belong to the Assistant tab only.
           Showing them on Context / Activity (a) was off-spec and
@@ -45,17 +47,6 @@ export function TimRailContainer() {
           <TimRailVoiceButton />
         </>
       )}
-    </View>
-  );
-}
-
-function ActivityPlaceholder() {
-  return (
-    <View style={styles.placeholder} testID="tim-rail-activity-placeholder">
-      <Text style={styles.placeholderTitle}>Activity</Text>
-      <Text style={styles.placeholderBody}>
-        Activity log lands in Pass 3.3.
-      </Text>
     </View>
   );
 }
@@ -76,39 +67,5 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: 0,
     overflow: 'hidden',
-  },
-  header: {
-    paddingHorizontal: 18,
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: 'rgba(255,255,255,0.06)',
-    gap: 2,
-  },
-  headerTitle: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: 'rgba(255,255,255,0.92)',
-    letterSpacing: -0.1,
-  },
-  headerSubtitle: {
-    fontSize: 11,
-    color: 'rgba(255,255,255,0.45)',
-  },
-  placeholder: {
-    flex: 1,
-    paddingHorizontal: 18,
-    paddingVertical: 24,
-    gap: 6,
-  },
-  placeholderTitle: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: 'rgba(255,255,255,0.85)',
-    letterSpacing: -0.1,
-  },
-  placeholderBody: {
-    fontSize: 12,
-    color: 'rgba(255,255,255,0.45)',
-    lineHeight: 18,
   },
 });

--- a/components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx
@@ -1,0 +1,441 @@
+/**
+ * TimRailControlsTab — the rail-side home for the Estimate Studio's
+ * chrome (address/search bar + studio tabs + quick actions).
+ *
+ * Why this exists:
+ *   On laptops + tablets (768 ≤ width < 1280), the canvas-level chrome
+ *   (header + slot + tab bar) eats the vertical space the hero/photos
+ *   need to breathe. We hoist that chrome INTO the Tim rail's third
+ *   tab so the canvas becomes pure visual content — hero + lane only.
+ *
+ *   On desktop (≥ 1280), the canvas-level chrome stays in place and
+ *   this tab renders only QUICK ACTIONS so it doesn't duplicate the
+ *   in-canvas affordances.
+ *
+ * Aspire Laws:
+ *   - #1 Single Brain: this is a render layer. Tapping a studio tab
+ *     calls `router.push(...)` — no autonomous routing decisions.
+ *   - #7 Tools Are Hands: Upload + New Project handlers come from a
+ *     shared hook (`useEstimateStudioActions`) so both this tab and
+ *     `ProjectAddressBar` invoke identical logic.
+ */
+import React from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  Pressable,
+  Platform,
+  useWindowDimensions,
+  type ViewStyle,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { usePathname, useRouter, type Href } from 'expo-router';
+import { ProjectAddressBar } from '../ProjectAddressBar';
+import { MaterialsSlotBar } from '../materials/MaterialsSlotBar';
+import { useEstimateStudioActions } from '@/hooks/useEstimateStudioActions';
+
+type IoniconsName = React.ComponentProps<typeof Ionicons>['name'];
+
+// Studio tab list — mirrors `EstimateStudioTabBar.tsx`. Kept in sync via
+// the regression test in __tests__/visuals/.
+const STUDIO_TABS: { id: string; label: string; icon: IoniconsName; route: Href }[] = [
+  { id: 'visuals',       label: 'Visuals',         icon: 'image-outline',           route: '/service-hub/estimate-studio/visuals' as Href },
+  { id: 'plans-photos',  label: 'Plans & Photos',  icon: 'document-attach-outline', route: '/service-hub/estimate-studio/plans-photos' as Href },
+  { id: 'scope',         label: 'Scope',           icon: 'list-outline',            route: '/service-hub/estimate-studio/scope' as Href },
+  { id: 'materials',     label: 'Materials',       icon: 'cube-outline',            route: '/service-hub/estimate-studio/materials' as Href },
+  { id: 'takeoff',       label: 'Takeoff',         icon: 'grid-outline',            route: '/service-hub/estimate-studio/takeoff' as Href },
+  { id: 'estimate',      label: 'Estimate',        icon: 'calculator-outline',      route: '/service-hub/estimate-studio/estimate' as Href },
+];
+
+// Desktop threshold — at this width and above, the in-canvas chrome is
+// visible, so the Controls tab hides PROJECT + NAVIGATE sections to avoid
+// duplicating affordances. Mirrors the LAPTOP_OR_TABLET_BREAKPOINT in
+// EstimateStudioShell.
+const DESKTOP_BREAKPOINT = 1280;
+
+// One-shot scrollbar-hide stylesheet (web only). Mirrors the pattern in
+// TimRailContextTab so the Controls tab scrolls without rendering a
+// browser scrollbar inside the rail.
+if (Platform.OS === 'web' && typeof document !== 'undefined') {
+  const STYLE_ID = 'tim-rail-controls-scrollbar-hide';
+  if (!document.getElementById(STYLE_ID)) {
+    const styleEl = document.createElement('style');
+    styleEl.id = STYLE_ID;
+    styleEl.textContent = `
+      [data-tim-rail-controls="1"] { scrollbar-width: none; -ms-overflow-style: none; }
+      [data-tim-rail-controls="1"]::-webkit-scrollbar { width: 0; height: 0; display: none; }
+    `;
+    document.head.appendChild(styleEl);
+  }
+}
+
+export function TimRailControlsTab() {
+  const pathname = usePathname() ?? '';
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const { onUpload, onNewProject } = useEstimateStudioActions();
+
+  const isMaterialsTab =
+    pathname.endsWith('/materials') || pathname.endsWith('/materials/');
+  const isDesktop = width >= DESKTOP_BREAKPOINT;
+  // On desktop the in-canvas chrome is already visible — hide the
+  // duplicate PROJECT and NAVIGATE sections; keep QUICK ACTIONS.
+  const showChromeSections = !isDesktop;
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      testID="tim-rail-controls-tab"
+      showsVerticalScrollIndicator={false}
+      showsHorizontalScrollIndicator={false}
+      // RN-Web maps `dataSet` onto data-* attributes (data-tim-rail-controls).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {...(Platform.OS === 'web' ? ({ dataSet: { timRailControls: '1' } } as any) : {})}
+    >
+      {showChromeSections && (
+        <Section title="PROJECT" testID="tim-rail-controls-project">
+          {isMaterialsTab ? <MaterialsSlotBar /> : <ProjectAddressBar />}
+        </Section>
+      )}
+
+      {showChromeSections && (
+        <Section title="NAVIGATE" testID="tim-rail-controls-navigate">
+          <View style={styles.tabGrid}>
+            {STUDIO_TABS.map((tab) => {
+              const routeStr = String(tab.route);
+              const isActive = pathname === routeStr || pathname === routeStr + '/';
+              return (
+                <StudioTabPill
+                  key={tab.id}
+                  label={tab.label}
+                  icon={tab.icon}
+                  isActive={isActive}
+                  onPress={() => router.push(tab.route)}
+                />
+              );
+            })}
+          </View>
+        </Section>
+      )}
+
+      <Section title="QUICK ACTIONS" testID="tim-rail-controls-actions">
+        <View style={styles.actionsStack}>
+          <SecondaryButton
+            label="Upload"
+            icon="cloud-upload-outline"
+            onPress={onUpload}
+            testID="tim-rail-controls-upload"
+            accessibilityLabel="Upload project evidence"
+          />
+          <PrimaryButton
+            label="New Project"
+            icon="add-outline"
+            onPress={onNewProject}
+            testID="tim-rail-controls-new-project"
+            accessibilityLabel="Start a new estimate project"
+          />
+        </View>
+      </Section>
+    </ScrollView>
+  );
+}
+
+// ─── Section ─────────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  children,
+  testID,
+}: {
+  title: string;
+  children: React.ReactNode;
+  testID?: string;
+}) {
+  return (
+    <View style={styles.section} testID={testID}>
+      <Text style={styles.sectionTitle} accessibilityRole="header">
+        {title}
+      </Text>
+      <View style={styles.sectionBody}>{children}</View>
+    </View>
+  );
+}
+
+// ─── Studio tab pill (2-col grid) ────────────────────────────────────────────
+
+function StudioTabPill({
+  label,
+  icon,
+  isActive,
+  onPress,
+}: {
+  label: string;
+  icon: IoniconsName;
+  isActive: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${label} tab`}
+      accessibilityState={{ selected: isActive }}
+      testID={`tim-rail-controls-tab-${label.toLowerCase().replace(/\s|&/g, '-')}`}
+      style={({ hovered, pressed, focused }: any) => [
+        styles.pill,
+        isActive && styles.pillActive,
+        !isActive && hovered && styles.pillHover,
+        pressed && styles.pillPressed,
+        focused && (styles.pillFocused as any),
+      ]}
+    >
+      <Ionicons
+        name={icon}
+        size={13}
+        color={isActive ? '#0A0A0F' : 'rgba(255,255,255,0.65)'}
+      />
+      <Text
+        style={[styles.pillLabel, isActive && styles.pillLabelActive]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+// ─── Buttons ─────────────────────────────────────────────────────────────────
+
+function SecondaryButton({
+  label,
+  icon,
+  onPress,
+  testID,
+  accessibilityLabel,
+}: {
+  label: string;
+  icon: IoniconsName;
+  onPress: () => void;
+  testID?: string;
+  accessibilityLabel: string;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={({ hovered, pressed, focused }: any) => [
+        styles.button,
+        styles.buttonSecondary,
+        hovered && styles.buttonSecondaryHover,
+        pressed && styles.buttonPressed,
+        focused && (styles.buttonFocused as any),
+      ]}
+    >
+      <Ionicons name={icon} size={15} color="rgba(255,255,255,0.85)" />
+      <Text style={styles.buttonLabelSecondary}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function PrimaryButton({
+  label,
+  icon,
+  onPress,
+  testID,
+  accessibilityLabel,
+}: {
+  label: string;
+  icon: IoniconsName;
+  onPress: () => void;
+  testID?: string;
+  accessibilityLabel: string;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={({ hovered, pressed, focused }: any) => [
+        styles.button,
+        styles.buttonPrimary,
+        hovered && styles.buttonPrimaryHover,
+        pressed && styles.buttonPressed,
+        focused && (styles.buttonFocusedPrimary as any),
+      ]}
+    >
+      <Ionicons name={icon} size={15} color="#0A0A0F" />
+      <Text style={styles.buttonLabelPrimary}>{label}</Text>
+    </Pressable>
+  );
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 12,
+    gap: 14,
+  },
+
+  // Section ----------------------------------------------------------------
+  section: {
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(255,255,255,0.06)',
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  sectionTitle: {
+    fontSize: 9.5,
+    fontWeight: '700',
+    letterSpacing: 1.4,
+    color: 'rgba(255,255,255,0.55)',
+    textTransform: 'uppercase',
+  },
+  sectionBody: {
+    gap: 8,
+  },
+
+  // 2-col tab grid ---------------------------------------------------------
+  tabGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    // 2 per row: (100% - 6px gap) / 2 — use flexBasis with grow to fill.
+    flexBasis: '48%',
+    flexGrow: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: 7,
+    backgroundColor: 'transparent',
+    minHeight: 32,
+    ...(Platform.OS === 'web'
+      ? (({
+          transition: 'all 180ms ease',
+          cursor: 'pointer',
+        } as unknown) as ViewStyle)
+      : {}),
+  },
+  pillActive: {
+    backgroundColor: '#ffffff',
+    ...(Platform.OS === 'web'
+      ? (({
+          backgroundImage: 'linear-gradient(135deg, #ffffff 0%, #e8e8e8 100%)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.25)',
+        } as unknown) as ViewStyle)
+      : {}),
+  },
+  pillHover: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  pillPressed: {
+    opacity: 0.85,
+  },
+  pillFocused: {
+    outlineWidth: 2,
+    outlineColor: '#fbbf24',
+    outlineStyle: 'solid',
+    outlineOffset: 2,
+  },
+  pillLabel: {
+    fontSize: 11,
+    fontWeight: '500',
+    color: 'rgba(255,255,255,0.65)',
+    letterSpacing: -0.1,
+    flexShrink: 1,
+  },
+  pillLabelActive: {
+    color: '#0A0A0F',
+    fontWeight: '600',
+  },
+
+  // Buttons ----------------------------------------------------------------
+  actionsStack: {
+    gap: 8,
+  },
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    minHeight: 44, // a11y tap target
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 8,
+    ...(Platform.OS === 'web'
+      ? (({
+          transition: 'all 180ms ease',
+          cursor: 'pointer',
+        } as unknown) as ViewStyle)
+      : {}),
+  },
+  buttonSecondary: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+  },
+  buttonSecondaryHover: {
+    backgroundColor: 'rgba(255,255,255,0.07)',
+    borderColor: 'rgba(255,255,255,0.16)',
+  },
+  buttonPrimary: {
+    backgroundColor: '#fbbf24',
+    ...(Platform.OS === 'web'
+      ? (({
+          backgroundImage: 'linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%)',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.25)',
+        } as unknown) as ViewStyle)
+      : {}),
+  },
+  buttonPrimaryHover: {
+    ...(Platform.OS === 'web'
+      ? (({
+          backgroundImage: 'linear-gradient(135deg, #fcd34d 0%, #fbbf24 100%)',
+          boxShadow: '0 2px 6px rgba(251,191,36,0.30)',
+        } as unknown) as ViewStyle)
+      : {}),
+  },
+  buttonPressed: {
+    opacity: 0.88,
+  },
+  buttonFocused: {
+    outlineWidth: 2,
+    outlineColor: '#fbbf24',
+    outlineStyle: 'solid',
+    outlineOffset: 2,
+  },
+  buttonFocusedPrimary: {
+    outlineWidth: 2,
+    outlineColor: '#fcd34d',
+    outlineStyle: 'solid',
+    outlineOffset: 2,
+  },
+  buttonLabelSecondary: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  buttonLabelPrimary: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#0A0A0F',
+    letterSpacing: -0.1,
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/TimRailTabSwitcher.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailTabSwitcher.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
-export type TimRailTabId = 'activity' | 'context' | 'assistant';
+export type TimRailTabId = 'controls' | 'context' | 'assistant';
 
 const tabs: { id: TimRailTabId; label: string }[] = [
-  { id: 'activity',  label: 'Activity' },
+  { id: 'controls',  label: 'Controls' },
   { id: 'context',   label: 'Context' },
   { id: 'assistant', label: 'Assistant' },
 ];

--- a/hooks/useEstimateStudioActions.ts
+++ b/hooks/useEstimateStudioActions.ts
@@ -1,0 +1,48 @@
+/**
+ * useEstimateStudioActions
+ *
+ * Shared action handlers for the Estimate Studio chrome (Upload evidence,
+ * New Project). Lives as a single hook so both the in-canvas
+ * `ProjectAddressBar` and the Tim Rail Controls tab call identical
+ * handlers — no copy-pasted business logic.
+ *
+ * Today the handlers are intentional stubs: file pickers and the
+ * project-creation flow are wired by downstream waves. Centralizing them
+ * here means future wiring updates ONE place.
+ *
+ * Aspire Law #7: pure UI plumbing — no autonomous state mutations beyond
+ * what user actions explicitly request.
+ */
+import { useCallback } from 'react';
+
+interface EstimateStudioActions {
+  onUpload: () => void;
+  onNewProject: () => void;
+}
+
+export function useEstimateStudioActions(): EstimateStudioActions {
+  const onUpload = useCallback(() => {
+    // Future: open evidence upload sheet (photos, PDFs, plans).
+    // Today: emit a benign event so the click is observable in dev.
+    if (typeof window !== 'undefined') {
+      try {
+        window.dispatchEvent(new CustomEvent('estimate-studio:upload'));
+      } catch {
+        /* noop */
+      }
+    }
+  }, []);
+
+  const onNewProject = useCallback(() => {
+    // Future: open the new-project flow (address + service + scope).
+    if (typeof window !== 'undefined') {
+      try {
+        window.dispatchEvent(new CustomEvent('estimate-studio:new-project'));
+      } catch {
+        /* noop */
+      }
+    }
+  }, []);
+
+  return { onUpload, onNewProject };
+}


### PR DESCRIPTION
## Summary
- Reorganize Tim Rail tabs `[Assistant, Context, Activity]` → `[Assistant, Context, Controls]`. Controls tab owns the studio chrome (address/search bar + studio nav + quick actions).
- Laptop/Tablet (768 ≤ w < 1280): canvas-level chrome HOISTED out of the main zone into Tim Rail. Outer canvas slimmed to `maxWidth: 880`, height `calc(100vh - 96px)`. Canvas becomes pure visual content (hero + lane). Replaces the height-dependent `isLaptop` heuristic that missed the 958×937 viewport.
- Desktop (≥ 1400): canvas chrome stays. Controls tab shows only Quick Actions to avoid duplicate affordances.
- Mobile (< 768): chrome stays in canvas; rail tabs unreachable at this width.

## Files changed
- **new** `hooks/useEstimateStudioActions.ts` — shared Upload + New Project handlers
- **new** `components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx` — 3 sections (PROJECT, NAVIGATE 2-col grid, QUICK ACTIONS)
- **new** `__tests__/visuals/tim-rail-controls.test.ts` — 16 regression locks
- **modified** `components/service-hub/estimate-studio/tim-rail/TimRailTabSwitcher.tsx` — `TimRailTabId` `'activity'` → `'controls'`
- **modified** `components/service-hub/estimate-studio/TimRailContainer.tsx` — wire Controls branch, drop `ActivityPlaceholder`
- **modified** `components/service-hub/estimate-studio/EstimateStudioShell.tsx` — `LAPTOP_OR_TABLET_BREAKPOINT = 1280`, chrome conditional, `canvasAreaFlush` style variant

## Design language
- Section headers: `9.5px / weight 700 / letter-spacing 1.4 / uppercase / rgba(255,255,255,0.55)` — matches Visuals locked spec
- Section cards: `bg rgba(255,255,255,0.02)`, hairline border `rgba(255,255,255,0.06)`, `borderRadius 10`
- Active tab pill: `linear-gradient(135deg, #ffffff → #e8e8e8)` + `0 1px 3px rgba(0,0,0,0.25)` — identical to `EstimateStudioTabBar` active
- Primary button: amber gradient `#fbbf24 → #f59e0b`, dark text
- All Pressables: web hover/press/focus states, `accessibilityRole=\"button\"`, `accessibilityLabel`, 44pt minimum tap target

## Test plan
- [x] `npx jest __tests__/visuals/` — **54 passed** (38 existing + 16 new)
- [x] `npx eslint <changed files>` — clean (0 errors / 0 warnings)
- [x] `npx tsc --noEmit` — zero new errors (2 pre-existing `TimRailContextTab` / `TimRailContainer` errors unchanged, out of scope)
- [ ] Visual QA: 958×937 viewport → chrome hoisted, canvas slim (880w), Controls tab shows PROJECT + NAVIGATE + QUICK ACTIONS
- [ ] Visual QA: ≥ 1400 viewport → in-canvas chrome unchanged, Controls tab shows only QUICK ACTIONS
- [ ] Visual QA: tablet 800px → rail stacks below; tap Controls tab; nav grid reachable

## Do not touch (respected)
- `TimRailContextTab.tsx` (locked, includes `MaterialsRouteContextCard`)
- `MaterialsSearchBar.tsx`, `MaterialsSearchContext.tsx`
- `EstimateStudioShell.tsx` outer amber `glowOverlay` system
- Visuals locks #13 / #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)