### PR TITLE
Wave 0: remove duplicate header controls (Upload/New Project/Recent)

### DIFF
--- a/__tests__/visuals/regression-lock.test.ts
+++ b/__tests__/visuals/regression-lock.test.ts
@@ -236,4 +236,51 @@ describe('Visuals Tab — Design Lock v1.0', () => {
       expect(shellMatch![0]).not.toMatch(/\baspectRatio\s*:/);
     });
   });
+
+  describe('Lock #15: ProjectAddressBar owns address input ONLY (Wave 0 cleanup)', () => {
+    // Wave 0 (2026-05-17): Upload, "+ New Project", and the "Recent ▾"
+    // dropdown were removed from the Estimate Studio header bar. Tim
+    // Rail Controls > Quick Actions is the single source of truth for
+    // Upload + New Project. This lock prevents them from being
+    // re-introduced into ProjectAddressBar.
+    const src = read(
+      'components/service-hub/estimate-studio/ProjectAddressBar.tsx',
+    );
+
+    it('does NOT render an Upload button', () => {
+      // Strip block comments so the rule comment in the file header
+      // doesn't trigger a false positive.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '');
+      expect(code).not.toMatch(/<Text[^>]*>Upload<\/Text>/);
+      expect(code).not.toMatch(/testID=["']estimate-studio-upload-evidence["']/);
+      expect(code).not.toMatch(/styles\.uploadButton\b/);
+    });
+
+    it('does NOT render a "New Project" button', () => {
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '');
+      expect(code).not.toMatch(/<Text[^>]*>New Project<\/Text>/);
+      expect(code).not.toMatch(/testID=["']estimate-studio-new-project["']/);
+      expect(code).not.toMatch(/styles\.newProjectButton\b/);
+    });
+
+    it('does NOT render the "Recent" dropdown chip', () => {
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '');
+      expect(code).not.toMatch(/<Text[^>]*>Recent<\/Text>/);
+      expect(code).not.toMatch(/styles\.recentChip\b/);
+    });
+
+    it('DOES still render the address TextInput with its anchor testID', () => {
+      expect(src).toMatch(/<TextInput\b/);
+      expect(src).toMatch(/testID=["']estimate-studio-address-input["']/);
+      expect(src).toMatch(/placeholder=["']Enter property address\.\.\.["']/);
+    });
+
+    it('drops the compact + onNewProject props from the public API', () => {
+      // The compact toggle existed only to hide the now-removed buttons,
+      // and onNewProject only wired the now-removed "+ New Project" button.
+      // Both must stay gone so callers don't pass dead props.
+      expect(src).not.toMatch(/\bcompact\??\s*:/);
+      expect(src).not.toMatch(/\bonNewProject\??\s*:/);
+    });
+  });
 });

--- a/components/service-hub/estimate-studio/ProjectAddressBar.tsx
+++ b/components/service-hub/estimate-studio/ProjectAddressBar.tsx
@@ -18,7 +18,6 @@ import {
   View,
   Text,
   TextInput,
-  TouchableOpacity,
   StyleSheet,
   ActivityIndicator,
   Pressable,
@@ -42,23 +41,19 @@ type PlaceSuggestion = {
 interface ProjectAddressBarProps {
   initialAddress?: string;
   onAddressChange?: (address: string) => void;
-  onNewProject?: () => void;
-  /**
-   * Compact mode hides the inline Upload + New Project buttons. Set true when
-   * rendering inside the Tim Rail Controls tab's PROJECT section — Controls
-   * has its own QUICK ACTIONS row, so duplicating the buttons here caused
-   * them to overlap the address input on laptops (reported 2026-05-13).
-   */
-  compact?: boolean;
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
+//
+// Wave 0 cleanup (2026-05-17): the inline Upload, "+ New Project" buttons
+// and the "Recent ▾" chip were removed. Tim Rail's Controls tab
+// (`TimRailControlsTab.tsx`) is the single source of truth for those actions
+// — duplicating them in the header bar created clutter and overlap on
+// laptops. The address input is the only affordance this component owns.
 
 export function ProjectAddressBar({
   initialAddress,
   onAddressChange,
-  onNewProject,
-  compact = false,
 }: ProjectAddressBarProps) {
   const { address: storedAddress } = useProjectAddress();
 
@@ -227,7 +222,6 @@ export function ProjectAddressBar({
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
-  const showRecentChip = draft.length === 0;
   const dropdownVisible =
     showDropdown && draft.trim().length >= 2 && (isFetchingSuggestions || suggestions.length > 0);
 
@@ -254,13 +248,6 @@ export function ProjectAddressBar({
             autoCapitalize="words"
             autoCorrect={false}
           />
-          {showRecentChip && (
-            <View style={styles.recentChip}>
-              <Ionicons name="time-outline" size={12} color="rgba(255,255,255,0.45)" />
-              <Text style={styles.recentChipText}>Recent</Text>
-              <Ionicons name="chevron-down" size={12} color="rgba(255,255,255,0.45)" />
-            </View>
-          )}
           {isFetchingSuggestions && (
             <ActivityIndicator size="small" color="rgba(255,255,255,0.45)" />
           )}
@@ -329,28 +316,6 @@ export function ProjectAddressBar({
         })()}
       </View>
 
-      {!compact && (
-        <>
-          <TouchableOpacity
-            style={styles.uploadButton}
-            activeOpacity={0.85}
-            testID="estimate-studio-upload-evidence"
-          >
-            <Ionicons name="cloud-upload-outline" size={16} color="rgba(255,255,255,0.85)" />
-            <Text style={styles.uploadButtonText}>Upload</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={styles.newProjectButton}
-            activeOpacity={0.85}
-            onPress={onNewProject}
-            testID="estimate-studio-new-project"
-          >
-            <Ionicons name="add" size={16} color="#0A0A0F" />
-            <Text style={styles.newProjectButtonText}>New Project</Text>
-          </TouchableOpacity>
-        </>
-      )}
     </View>
   );
 }
@@ -391,16 +356,13 @@ function parseSuggestions(raw: unknown[]): PlaceSuggestion[] {
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 8,
     paddingVertical: 8,
     marginBottom: 16,
     zIndex: 9999,
     position: 'relative',
   },
   searchWrap: {
-    flex: 1,
+    width: '100%',
     position: 'relative',
     zIndex: 9999,
   },
@@ -422,22 +384,6 @@ const styles = StyleSheet.create({
     padding: 0,
     margin: 0,
     outlineStyle: 'none' as any,
-  },
-  recentChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
-    backgroundColor: 'rgba(255,255,255,0.04)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.08)',
-  },
-  recentChipText: {
-    fontSize: 11,
-    color: 'rgba(255,255,255,0.55)',
-    fontWeight: '500',
   },
   dropdown: {
     position: 'absolute',
@@ -492,37 +438,5 @@ const styles = StyleSheet.create({
   suggestionSecondary: {
     fontSize: 11,
     color: 'rgba(255,255,255,0.55)',
-  },
-  uploadButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 12,
-    paddingVertical: 9,
-    borderRadius: 10,
-    backgroundColor: '#1C1C1E',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.06)',
-  },
-  uploadButtonText: {
-    fontSize: 12,
-    fontWeight: '500',
-    color: 'rgba(255,255,255,0.85)',
-    letterSpacing: -0.1,
-  },
-  newProjectButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: 14,
-    paddingVertical: 9,
-    borderRadius: 10,
-    backgroundColor: '#fbbf24',
-  },
-  newProjectButtonText: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: '#0A0A0F',
-    letterSpacing: -0.1,
   },
 });

--- a/components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx
@@ -99,10 +99,10 @@ export function TimRailControlsTab() {
     >
       {showChromeSections && (
         <Section title="PROJECT" testID="tim-rail-controls-project">
-          {/* compact={true} hides ProjectAddressBar's inline Upload + New
-              Project buttons that were overlapping the address input. The
-              QUICK ACTIONS section below owns those buttons. */}
-          {isMaterialsTab ? <MaterialsSlotBar /> : <ProjectAddressBar compact />}
+          {/* ProjectAddressBar now owns the address input only — Upload +
+              New Project moved permanently to QUICK ACTIONS below (Wave 0
+              header cleanup, 2026-05-17). */}
+          {isMaterialsTab ? <MaterialsSlotBar /> : <ProjectAddressBar />}
         </Section>
       )}
 


### PR DESCRIPTION
## 1) Objective
Reclaim header real estate on the Estimate Studio screen by deleting three duplicate UI controls from `ProjectAddressBar`. Tim Rail's **Controls** tab > Quick Actions is the single source of truth for Upload + New Project; the header-bar duplicates were clutter and (per the 2026-05-13 report referenced in code comments) overlapped the address input on laptops.

Wave 0 of the Blueprint Story Engine plan (`~/.claude/plans/serene-seeking-hollerith.md`).

## 2) Facts (verified)
- **Header component is two pieces**: `EstimateStudioHeader.tsx` renders only the page title + BETA chip + tagline (already clean — untouched). `ProjectAddressBar.tsx` was rendering address input **+ Upload + "+ New Project" + "Recent ▾"** as a flex row beneath it.
- **Shared action handlers** live at `hooks/useEstimateStudioActions.ts` (`onUpload`, `onNewProject`). `TimRailControlsTab.tsx` already invokes them from its QUICK ACTIONS row (verified lines 80, 129–145).
- **Two render sites** call `<ProjectAddressBar />`: `EstimateStudioShell.tsx:149` (canvas chrome) and `TimRailControlsTab.tsx:105` (laptop/tablet hoisted chrome). Neither passed `onNewProject`; only the rail call passed `compact`.

## 3) Decision
Delete the three controls from `ProjectAddressBar`, drop the now-orphan `compact` and `onNewProject` props, and let Tim Rail's QUICK ACTIONS remain authoritative. Add a content-invariant regression-lock test alongside the existing Lock #1–#14 suite to prevent re-introduction.

The `compact` prop existed *only* to hide the buttons we just removed, so it has no remaining purpose. Removing it forces both callsites to converge on a single bare `<ProjectAddressBar />` JSX shape.

## 4) Changes
- `components/service-hub/estimate-studio/ProjectAddressBar.tsx` — remove `<TouchableOpacity>` Upload + New Project buttons, remove the inline `Recent` chip, drop the `compact` + `onNewProject` props, simplify container styles (no longer a row with three siblings; address bar is full-width), drop unused styles (`uploadButton`, `uploadButtonText`, `newProjectButton`, `newProjectButtonText`, `recentChip`, `recentChipText`) and the unused `TouchableOpacity` import.
- `components/service-hub/estimate-studio/tim-rail/TimRailControlsTab.tsx` — drop the `compact` prop at the `<ProjectAddressBar />` callsite (line 105). Refreshed the inline comment to point at the Wave 0 rationale.
- `__tests__/visuals/regression-lock.test.ts` — add **Lock #15: ProjectAddressBar owns address input ONLY (Wave 0 cleanup)** with 5 assertions: (a) no Upload text/testID/style, (b) no "New Project" text/testID/style, (c) no "Recent" text or `recentChip` style, (d) the address `TextInput` + its `estimate-studio-address-input` testID + placeholder are still present, (e) `compact` + `onNewProject` props are gone from the public API.

Untouched (per scope): page title, BETA chip, tagline, autocomplete fetch logic, Address Validation gate, focus/hover states, Tim Rail. CLS=0 preserved — the header row simply collapses to a single full-width input below the title.

## 5) Verification
**Regression-lock tests** — Lock #15 (5 tests) **all pass**:
```
PASS __tests__/visuals/regression-lock.test.ts
  Lock #15: ProjectAddressBar owns address input ONLY (Wave 0 cleanup)
    ✓ does NOT render an Upload button
    ✓ does NOT render a "New Project" button
    ✓ does NOT render the "Recent" dropdown chip
    ✓ DOES still render the address TextInput with its anchor testID
    ✓ drops the compact + onNewProject props from the public API
```

**Suite totals**: 55 passing on branch vs 50 on baseline `main` → +5 new green tests, **zero new failures**.

**Pre-existing failures (unchanged by this PR)**:
- `Lock #2: Street View Pano initial zoom = 2` (touches `LiveStreetViewHero.tsx` — not in this PR's diff)
- 3 failures in `tim-rail-controls.test.ts` referencing `maxWidth=880` / `calc(100vh - 96px)` chrome-hoist assertions (touch `EstimateStudioShell.tsx` — not in this PR's diff)

Verified pre-existing by running the same suites on a clean `main` checkout: identical 4 failures, 50 passes.

**TypeScript**: `npx tsc --noEmit` reports no new errors. The single `react-dom` declaration warning on `ProjectAddressBar.tsx` line 26 is pre-existing (was line 27 on `main`; the createPortal import is untouched).

**Visual confirmation** of the new header layout — title row + BETA chip + tagline + single full-width address input. No row of trailing buttons.

## 6) Risks & Next Steps
**Risks**
- **External callers passing the removed props**: a `grep` across `Aspire-desktop` shows only the two known call sites (`EstimateStudioShell.tsx`, `TimRailControlsTab.tsx`), neither of which passed `onNewProject`; only the rail passed `compact` and that callsite is updated in this PR. Low risk.
- **Discoverability of Upload/New Project**: users now find them only in the Tim Rail Controls tab. Pre-existing duplication was confusing; Controls is already where the laptop/tablet chrome lives. Acceptable.
- **`Recent ▾` removal**: the chip was a visual stub (it had no dropdown menu wired) — net UX win, no regression of real behavior.

**Next Critic Tasks**
- [ ] Verify Tim Rail Controls > Quick Actions Upload + New Project still render and invoke on laptop (768–1499px) **and** desktop (≥1500px).
- [ ] Confirm address autocomplete still opens at full container width (no clipping from the removed sibling buttons' former gap).
- [ ] Confirm no e2e/visual snapshot tests pinned the old 3-button header geometry (none found in grep).
- [ ] Wave 1+ of the Blueprint Story Engine plan can now proceed against the cleaner header.

---
Co-Authored-By: Claude Opus 4.7 (1M context)