### PR TITLE
Wave 6A: Plans & Photos production upload + sheet roster

### DIFF
--- a/__tests__/visuals/regression-lock.test.ts
+++ b/__tests__/visuals/regression-lock.test.ts
@@ -283,4 +283,42 @@ describe('Visuals Tab — Design Lock v1.0', () => {
       expect(src).not.toMatch(/\bonNewProject\??\s*:/);
     });
   });
+
+  describe('Lock #16: Plans & Photos tab uses shared shell (CanvasCardSwitcher + BottomChipStrip)', () => {
+    // Wave 6A (2026-05-17): Plans & Photos is the primary upload entry for
+    // the Blueprint Story Engine. It must use the shared canvas-card switcher
+    // shell so future waves (Scope, Takeoff) inherit the same geometry
+    // instead of re-implementing free-form layouts per tab.
+    const tabSrc = read(
+      'components/service-hub/estimate-studio/plans-photos/PlansPhotosTab.tsx',
+    );
+    const pageSrc = read('app/service-hub/estimate-studio/plans-photos.tsx');
+
+    it('uses <CanvasCardSwitcher /> for the main canvas region', () => {
+      expect(tabSrc).toMatch(/CanvasCardSwitcher/);
+      expect(tabSrc).toMatch(/<CanvasCardSwitcher\b/);
+    });
+
+    it('uses <BottomChipStrip /> for card selection', () => {
+      expect(tabSrc).toMatch(/BottomChipStrip/);
+      expect(tabSrc).toMatch(/<BottomChipStrip\b/);
+    });
+
+    it('uses <UploadDropZone /> (not a free-form upload form)', () => {
+      expect(tabSrc).toMatch(/UploadDropZone/);
+      expect(tabSrc).toMatch(/<UploadDropZone\b/);
+    });
+
+    it('plans-photos.tsx route delegates to <PlansPhotosTab /> (no TabPlaceholder)', () => {
+      expect(pageSrc).toMatch(/<PlansPhotosTab\s*\/>/);
+      expect(pageSrc).not.toMatch(/TabPlaceholder/);
+    });
+
+    it('renders the Wave 6.5 coming-soon banner so reviewers know what is deferred', () => {
+      // The banner explains thumbnails + 5-stage progress land in Wave 6.5.
+      // The literal string must remain so the visible UX matches the contract.
+      expect(tabSrc).toMatch(/Wave 6\.5/);
+      expect(tabSrc).toMatch(/Wave 2\.5/);
+    });
+  });
 });

--- a/app/service-hub/estimate-studio/plans-photos.tsx
+++ b/app/service-hub/estimate-studio/plans-photos.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import { TabPlaceholder } from '@/components/service-hub/estimate-studio/TabPlaceholder';
+import { PlansPhotosTab } from '@/components/service-hub/estimate-studio/plans-photos/PlansPhotosTab';
 
-export default function PlansPhotosTab() {
-  return (
-    <TabPlaceholder
-      tabName="Plans & Photos"
-      phaseN={4}
-      icon="document-attach-outline"
-      description="Evidence intake — plans, sheets, photos, submittals. Discipline auto-detection. Push to Scope or Takeoff. Phase 4."
-    />
-  );
+export default function PlansPhotosTabRoute() {
+  return <PlansPhotosTab />;
 }

--- a/components/desktop/DesktopHome.tsx
+++ b/components/desktop/DesktopHome.tsx
@@ -407,21 +407,16 @@ function DesktopHomeInner() {
   }, [session?.access_token, suiteId]);
 
   // ── Responsive column widths (spec p13 viewport matrix, Canvas.layout tokens) ──
-  // Tablet-landscape band (1024–1279) collapses to a 2-COLUMN layout: center
-  // stage + right rail only. The left strip (Interaction Mode + Today's Plan)
-  // stacks above via `tabletTopRow`. Reason: at 1180px viewport, the prior
-  // 3-col 208+12+440+12+220 distribution was forcing Ops Snapshot widget
-  // content (Connect-accounts CTA + Service tier pill) past the right edge.
-  const isTabletLandscape =
-    Platform.OS === 'web' &&
-    width >= Canvas.layout.tabletLandscapeLower &&
-    width < Canvas.layout.tabletLandscapeUpper;
-  const tabletDesktopFit = Platform.OS === 'web' && width >= 768 && width < 1280 && !isTabletLandscape;
+  // iPad landscape (1024-1279 — viewport-fixed 2026-05-17) uses the SAME 3-col
+  // layout as desktop with the compact tabletDesktopFit widths (208 / flex / 220
+  // + 12px gaps). Fits in 1100 maxWidth contentInner with the shell's iPad-
+  // landscape gutter. The earlier 2-col workaround was masking the wrong-viewport
+  // bug (server was forcing width=1280); now that viewport reports the real
+  // device width, the standard 3-col fits.
+  const tabletDesktopFit = Platform.OS === 'web' && width >= 768 && width < 1280;
   const compactTabletFit = Platform.OS === 'web' && width >= 768 && width < 920;
   const leftWidth = compactTabletFit
     ? 176
-    : isTabletLandscape
-    ? 0
     : tabletDesktopFit
     ? 208
     : isTablet
@@ -431,8 +426,6 @@ function DesktopHomeInner() {
         : Canvas.layout.leftColDesktop;
   const rightWidth = compactTabletFit
     ? 188
-    : isTabletLandscape
-      ? Canvas.layout.rightColTabletLandscape
     : tabletDesktopFit
       ? 220
     : isTablet
@@ -440,15 +433,9 @@ function DesktopHomeInner() {
       : isLaptop
         ? Canvas.layout.rightColLaptop
         : Canvas.layout.rightColDesktop;
-  // Tablet-landscape uses a 2-col layout (left stacks above). Drive showThreeCol
-  // false in that band so the existing tabletTopRow path renders the left strip
-  // above the center+right row.
-  const showThreeCol =
-    Platform.OS === 'web' ? width >= 768 && !isTabletLandscape : !isTablet;
+  const showThreeCol = Platform.OS === 'web' ? width >= 768 : !isTablet;
   const columnGap = compactTabletFit
     ? 10
-    : isTabletLandscape
-      ? Canvas.layout.gapTablet
     : tabletDesktopFit
       ? Canvas.layout.gapTablet
     : isTablet
@@ -456,6 +443,14 @@ function DesktopHomeInner() {
       : isLaptop
         ? Canvas.layout.gapLaptop
         : Canvas.layout.gapDesktop;
+  // Keep the symbol exported for any callers tracking the old token — but
+  // it's no longer used to gate layout; the shell maxWidth=1100 in the
+  // iPad-landscape band already provides the polite gutter.
+  const isTabletLandscape =
+    Platform.OS === 'web' &&
+    width >= Canvas.layout.tabletLandscapeLower &&
+    width < Canvas.layout.tabletLandscapeUpper;
+  void isTabletLandscape;
   const isWide = width >= 1920;
   const workspaceHeight = Math.max(640, Math.min(840, height - 150));
 
@@ -547,10 +542,10 @@ function DesktopHomeInner() {
                 </View>
                 )}
 
-                {/* Tablet / tablet-landscape: left column content stacks above center.
-                    At iPad landscape (1024-1279) we keep BOTH Interaction Mode and
-                    Today's Plan above the center+right row so nothing is lost when
-                    we drop the left strip. */}
+                {/* Narrow tablet portrait (<768 with web, or non-web isTablet):
+                    keep the legacy single-card stack-above-center path. iPad
+                    landscape now uses the standard 3-col branch above since
+                    the viewport reports the real device width. */}
                 {!showThreeCol && (
                   <View style={styles.tabletTopRow}>
                     <CanvasTileWrapper
@@ -566,26 +561,6 @@ function DesktopHomeInner() {
                         <InteractionModePanel options={INTERACTION_MODES} />
                       </View>
                     </CanvasTileWrapper>
-                    {isTabletLandscape && (
-                      <CanvasTileWrapper
-                        tileId="inbox_setup"
-                        mode={mode}
-                        onPress={handleTilePress}
-                        onHoverIn={handleTileHoverIn}
-                        onHoverOut={handleTileHoverOut}
-                        onContextMenu={handleContextMenu}
-                      >
-                        <View style={[styles.section, styles.tabletTopRowPlan]}>
-                          <SectionHeader
-                            title="Today's Plan"
-                            subtitle={`${planItems.length} tasks`}
-                            actionLabel="See all"
-                            onAction={() => router.push('/session/plan' as any)}
-                          />
-                          <TodayPlanTabs planItems={planItems} />
-                        </View>
-                      </CanvasTileWrapper>
-                    )}
                   </View>
                 )}
 

--- a/components/service-hub/estimate-studio/plans-photos/PlansPhotosTab.tsx
+++ b/components/service-hub/estimate-studio/plans-photos/PlansPhotosTab.tsx
@@ -1,0 +1,380 @@
+/**
+ * PlansPhotosTab — Wave 6A.
+ *
+ * Owner of the Plans & Photos UX. Two states:
+ *
+ *   Empty (no project yet):
+ *     - Big <UploadDropZone /> hero takes the canvas
+ *     - Bottom chip strip shows only "📤 Upload" enabled; the other chips
+ *       are disabled placeholders for future views
+ *
+ *   Populated (a project landed):
+ *     - <CanvasCardSwitcher /> hosts the chip-selected card
+ *     - Default view = "📑 All Sheets" (the SheetRoster)
+ *     - Bottom chip strip switches between Upload / All Sheets /
+ *       By Discipline / Revisions
+ *
+ * Wave 6A reality: thumbnails, polling, and per-sheet discipline tags
+ * land in Wave 6.5. A wave-coming-soon banner makes this visible to
+ * localhost reviewers (per Tonio's directive).
+ *
+ * Law #7: render layer only. All decisions happen in the hook.
+ */
+import React, { useMemo, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useBlueprintUpload } from '@/hooks/useBlueprintUpload';
+import { CanvasCardSwitcher } from '../shell/CanvasCardSwitcher';
+import { BottomChipStrip, type BottomChip } from '../shell/BottomChipStrip';
+import { UploadDropZone } from './UploadDropZone';
+import { SheetRoster } from './SheetRoster';
+import { UploadProgressInline } from './UploadProgressInline';
+import { getDisciplineStyle } from './disciplines';
+
+type CardKey = 'upload' | 'sheets' | 'disciplines' | 'revisions';
+
+const COMING_SOON_NOTE =
+  'Thumbnails + 5-stage progress land in Wave 6.5 (waiting on Wave 2.5 backend reads + Wave 3 SEE).';
+
+export function PlansPhotosTab(): React.ReactElement {
+  const upload = useBlueprintUpload();
+  const [activeCard, setActiveCard] = useState<CardKey>('upload');
+
+  const hasProject = upload.phase === 'success' && upload.response != null;
+  const sheetCount = upload.response?.ingest.sheet_count ?? 0;
+  const disciplineCounts = upload.response?.classify?.discipline_counts ?? {};
+  const revisions = upload.response?.classify?.revisions ?? 0;
+  const needsReview = upload.response?.classify?.needs_review_count ?? 0;
+  const sheetIds = upload.response?.ingest.sheet_ids ?? [];
+
+  // Auto-jump to Sheets when an upload finishes (premium UX: don't make
+  // the user click).
+  React.useEffect(() => {
+    if (hasProject && activeCard === 'upload') {
+      setActiveCard('sheets');
+    }
+  }, [hasProject, activeCard]);
+
+  const chips: BottomChip<CardKey>[] = useMemo(
+    () => [
+      {
+        key: 'upload',
+        icon: 'cloud-upload-outline',
+        label: 'Upload',
+        stat: hasProject ? 'Add another' : 'Drop a plan set',
+      },
+      {
+        key: 'sheets',
+        icon: 'documents-outline',
+        label: 'All Sheets',
+        stat: hasProject ? `${sheetCount} sheets` : 'Upload to enable',
+        badge: hasProject ? `${sheetCount}` : undefined,
+        disabled: !hasProject,
+      },
+      {
+        key: 'disciplines',
+        icon: 'color-palette-outline',
+        label: 'By Discipline',
+        stat: hasProject
+          ? `${Object.keys(disciplineCounts).length} tags`
+          : 'Upload to enable',
+        disabled: !hasProject || Object.keys(disciplineCounts).length === 0,
+      },
+      {
+        key: 'revisions',
+        icon: 'time-outline',
+        label: 'Revisions',
+        stat: hasProject ? `${revisions} found` : 'Upload to enable',
+        disabled: !hasProject,
+      },
+    ],
+    [hasProject, sheetCount, disciplineCounts, revisions],
+  );
+
+  const cards: Record<CardKey, React.ReactNode> = {
+    upload: (
+      <UploadDropZone
+        phase={upload.phase}
+        progress={upload.progress}
+        filename={upload.filename}
+        stageProgress={upload.stageProgress}
+        error={upload.error}
+        onFile={upload.upload}
+        onReset={upload.reset}
+      />
+    ),
+    sheets: hasProject ? (
+      <SheetRoster
+        sheetIds={sheetIds}
+        disciplineCounts={disciplineCounts}
+        revisions={revisions}
+        needsReviewCount={needsReview}
+      />
+    ) : (
+      <EmptyCardPlaceholder
+        icon="documents-outline"
+        title="No sheets yet"
+        body="Upload a plan set to see the roster."
+      />
+    ),
+    disciplines: hasProject ? (
+      <DisciplineBreakdownCard counts={disciplineCounts} />
+    ) : (
+      <EmptyCardPlaceholder
+        icon="color-palette-outline"
+        title="No disciplines yet"
+        body="Upload a plan set so Drew can classify the sheets."
+      />
+    ),
+    revisions: hasProject ? (
+      <EmptyCardPlaceholder
+        icon="time-outline"
+        title={`${revisions} revision${revisions === 1 ? '' : 's'} detected`}
+        body="Full revision-chain UI (per-sheet supersedes + tooltips) ships in Wave 6.5."
+      />
+    ) : (
+      <EmptyCardPlaceholder
+        icon="time-outline"
+        title="No revisions yet"
+        body="Upload a plan set first."
+      />
+    ),
+  };
+
+  return (
+    <View style={styles.tab} testID="plans-photos-tab">
+      {/* Wave 6A coming-soon banner so localhost reviewers know what's deferred. */}
+      <View style={styles.banner} accessibilityRole="alert" testID="plans-photos-wave-banner">
+        <Ionicons name="information-circle-outline" size={13} color="#fbbf24" />
+        <Text style={styles.bannerText}>{COMING_SOON_NOTE}</Text>
+      </View>
+
+      {/* Inline pipeline indicator — always visible so users see ingest → classify happen. */}
+      {upload.phase !== 'idle' ? (
+        <View style={styles.progressStrip}>
+          <UploadProgressInline stages={upload.stageProgress} layout="horizontal" />
+        </View>
+      ) : null}
+
+      <View style={styles.canvas}>
+        <CanvasCardSwitcher
+          activeCardKey={activeCard}
+          cards={cards}
+          testID="plans-photos-canvas-switcher"
+        />
+      </View>
+
+      <BottomChipStrip
+        chips={chips}
+        activeKey={activeCard}
+        onChange={setActiveCard}
+        testID="plans-photos-chip-strip"
+      />
+    </View>
+  );
+}
+
+function EmptyCardPlaceholder({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  title: string;
+  body: string;
+}): React.ReactElement {
+  return (
+    <View style={styles.placeholderHost}>
+      <View style={styles.placeholderIconCircle}>
+        <Ionicons name={icon} size={28} color="rgba(255,255,255,0.55)" />
+      </View>
+      <Text style={styles.placeholderTitle}>{title}</Text>
+      <Text style={styles.placeholderBody}>{body}</Text>
+    </View>
+  );
+}
+
+function DisciplineBreakdownCard({ counts }: { counts: Record<string, number> }): React.ReactElement {
+  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) {
+    return (
+      <EmptyCardPlaceholder
+        icon="color-palette-outline"
+        title="No discipline tags yet"
+        body="Drew didn't find recognisable discipline markers on this plan set."
+      />
+    );
+  }
+  const total = entries.reduce((sum, [, n]) => sum + n, 0);
+  return (
+    <View style={styles.discHost} testID="discipline-breakdown-card">
+      <Text style={styles.discTitle}>Discipline Breakdown</Text>
+      <Text style={styles.discSubtitle}>
+        {total} classified entr{total === 1 ? 'y' : 'ies'} across {entries.length} discipline
+        {entries.length === 1 ? '' : 's'}.
+      </Text>
+      <View style={styles.discList}>
+        {entries.map(([disc, count]) => {
+          const style = getDisciplineStyle(disc);
+          const pct = total > 0 ? (count / total) * 100 : 0;
+          return (
+            <View key={disc} style={styles.discRow}>
+              <View
+                style={[styles.discRowCodeWrap, { backgroundColor: style.fg + '22' }]}
+              >
+                <Text style={[styles.discRowCode, { color: style.fg }]}>{style.code}</Text>
+              </View>
+              <View style={styles.discRowBody}>
+                <View style={styles.discRowHeader}>
+                  <Text style={styles.discRowLabel}>{style.label}</Text>
+                  <Text style={styles.discRowCount}>
+                    {count} ({pct.toFixed(0)}%)
+                  </Text>
+                </View>
+                <View style={styles.discRowTrack}>
+                  <View
+                    style={[
+                      styles.discRowFill,
+                      { width: `${pct}%`, backgroundColor: style.fg },
+                    ]}
+                  />
+                </View>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tab: {
+    flex: 1,
+    padding: 18,
+    gap: 12,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: 'rgba(251,191,36,0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.22)',
+  },
+  bannerText: {
+    flex: 1,
+    fontSize: 10.5,
+    color: 'rgba(251,191,36,0.85)',
+    letterSpacing: -0.05,
+    lineHeight: 14,
+  },
+  progressStrip: {
+    paddingHorizontal: 2,
+    paddingVertical: 2,
+  },
+  canvas: {
+    flex: 1,
+    minHeight: 320,
+  },
+  placeholderHost: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  placeholderIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  placeholderTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  placeholderBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 360,
+    lineHeight: 17,
+  },
+
+  discHost: {
+    flex: 1,
+    padding: 16,
+    gap: 14,
+  },
+  discTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.2,
+  },
+  discSubtitle: {
+    fontSize: 11.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+  },
+  discList: {
+    gap: 10,
+  },
+  discRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  discRowCodeWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  discRowCode: {
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  discRowBody: {
+    flex: 1,
+    gap: 4,
+  },
+  discRowHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+  },
+  discRowLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  discRowCount: {
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+  },
+  discRowTrack: {
+    height: 5,
+    borderRadius: 3,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    overflow: 'hidden',
+  },
+  discRowFill: {
+    height: '100%',
+    borderRadius: 3,
+  },
+});

--- a/components/service-hub/estimate-studio/plans-photos/RevisionBadge.tsx
+++ b/components/service-hub/estimate-studio/plans-photos/RevisionBadge.tsx
@@ -1,0 +1,64 @@
+/**
+ * RevisionBadge — Wave 6A.
+ *
+ * Small colored chip for a sheet's revision state.
+ *
+ * Wave 6A: Drew CLASSIFY returns a `revisions` count but no per-sheet
+ * revision chain (that's Wave 6.5 once the GET /sheets endpoint lands).
+ * For now we render "REV {n}" when n > 0 OR a plain "REV" pill. The
+ * tooltip+hover chain UI ships in Wave 6.5.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+interface Props {
+  revision?: number | null;
+  superseded?: boolean;
+  testID?: string;
+}
+
+export function RevisionBadge({ revision, superseded, testID }: Props): React.ReactElement | null {
+  if (!superseded && (revision == null || revision === 0)) return null;
+
+  const label = superseded ? 'SUPERSEDED' : `REV ${revision}`;
+  return (
+    <View
+      style={[styles.badge, superseded ? styles.badgeSuperseded : styles.badgeActive]}
+      testID={testID ?? 'revision-badge'}
+      accessibilityLabel={superseded ? 'Sheet superseded by newer revision' : `Revision ${revision}`}
+    >
+      <Text style={[styles.text, superseded ? styles.textSuperseded : styles.textActive]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 1,
+  },
+  badgeActive: {
+    backgroundColor: 'rgba(251,191,36,0.10)',
+    borderColor: 'rgba(251,191,36,0.40)',
+  },
+  badgeSuperseded: {
+    backgroundColor: 'rgba(148,163,184,0.06)',
+    borderColor: 'rgba(148,163,184,0.30)',
+  },
+  text: {
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.7,
+  },
+  textActive: {
+    color: '#fbbf24',
+  },
+  textSuperseded: {
+    color: 'rgba(148,163,184,0.95)',
+    textDecorationLine: 'line-through',
+  },
+});

--- a/components/service-hub/estimate-studio/plans-photos/SheetRoster.tsx
+++ b/components/service-hub/estimate-studio/plans-photos/SheetRoster.tsx
@@ -1,0 +1,304 @@
+/**
+ * SheetRoster — Wave 6A.
+ *
+ * Roster view of the sheets Drew INGEST stored. Wave 6A surfaces just the
+ * `sheet_ids` array + `discipline_counts` from the synchronous upload
+ * response — there is NO per-sheet thumbnail or per-sheet discipline tag
+ * available yet (backend GET /sheets ships in Wave 2.5; thumbnails in
+ * Wave 6.5).
+ *
+ * The roster therefore renders:
+ *   - A header strip of discipline-count chips (real data from CLASSIFY).
+ *   - A flat list of sheet IDs with their index + a "?" discipline placeholder.
+ *
+ * Wave 6.5 will replace this component with a real <SheetThumbnailGrid />.
+ */
+import React from 'react';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { getDisciplineStyle } from './disciplines';
+import { RevisionBadge } from './RevisionBadge';
+
+interface Props {
+  /** Sheet IDs from INGEST response (one per page). */
+  sheetIds: string[];
+  /** Discipline → count, from CLASSIFY response. */
+  disciplineCounts: Record<string, number>;
+  revisions: number;
+  needsReviewCount: number;
+  testID?: string;
+}
+
+export function SheetRoster({
+  sheetIds,
+  disciplineCounts,
+  revisions,
+  needsReviewCount,
+  testID,
+}: Props): React.ReactElement {
+  const totalDisciplineHits = Object.values(disciplineCounts).reduce((a, b) => a + b, 0);
+  const orderedDisciplines = Object.entries(disciplineCounts).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <View style={styles.host} testID={testID ?? 'sheet-roster'}>
+      {/* Discipline summary chip row */}
+      <View style={styles.summaryRow}>
+        <View style={styles.statBlock}>
+          <Text style={styles.statValue}>{sheetIds.length}</Text>
+          <Text style={styles.statLabel}>sheets</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statBlock}>
+          <Text style={styles.statValue}>{orderedDisciplines.length}</Text>
+          <Text style={styles.statLabel}>disciplines</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statBlock}>
+          <Text style={styles.statValue}>{revisions}</Text>
+          <Text style={styles.statLabel}>revisions</Text>
+        </View>
+        {needsReviewCount > 0 ? (
+          <>
+            <View style={styles.statDivider} />
+            <View style={styles.statBlock}>
+              <Text style={[styles.statValue, styles.statValueWarn]}>{needsReviewCount}</Text>
+              <Text style={styles.statLabel}>need review</Text>
+            </View>
+          </>
+        ) : null}
+      </View>
+
+      {/* Discipline chip row */}
+      {orderedDisciplines.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.disciplineRow}
+        >
+          {orderedDisciplines.map(([disc, count]) => {
+            const style = getDisciplineStyle(disc);
+            return (
+              <View
+                key={disc}
+                style={[styles.discChip, { backgroundColor: style.bg, borderColor: style.fg + '55' }]}
+                testID={`discipline-chip-${disc}`}
+              >
+                <View style={[styles.discCodeWrap, { backgroundColor: style.fg + '22' }]}>
+                  <Text style={[styles.discCode, { color: style.fg }]}>{style.code}</Text>
+                </View>
+                <View style={styles.discBody}>
+                  <Text style={styles.discLabel}>{style.label}</Text>
+                  <Text style={styles.discCount}>
+                    {count} sheet{count === 1 ? '' : 's'}
+                  </Text>
+                </View>
+              </View>
+            );
+          })}
+        </ScrollView>
+      ) : null}
+
+      {/* Sheet list (Wave 6A: no thumbnails, no per-sheet discipline tags). */}
+      <View style={styles.listHeader}>
+        <Text style={styles.listHeaderText}>SHEETS</Text>
+        <Text style={styles.listHeaderHint}>
+          {totalDisciplineHits === 0
+            ? 'Classification in progress…'
+            : 'Per-sheet discipline tags ship in Wave 6.5 (waiting on backend GET /sheets).'}
+        </Text>
+      </View>
+
+      <ScrollView
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {sheetIds.map((sheetId, idx) => (
+          <View key={sheetId} style={styles.row} testID={`sheet-row-${idx}`}>
+            <View style={styles.rowIdx}>
+              <Text style={styles.rowIdxText}>{idx + 1}</Text>
+            </View>
+            <View style={styles.rowDisc}>
+              <Text style={styles.rowDiscText}>—</Text>
+            </View>
+            <View style={styles.rowBody}>
+              <Text style={styles.rowSheetNo}>Sheet {idx + 1}</Text>
+              <Text style={styles.rowSheetId} numberOfLines={1}>
+                {sheetId}
+              </Text>
+            </View>
+            <View style={styles.rowMeta}>
+              <RevisionBadge revision={null} />
+              <Ionicons name="chevron-forward" size={14} color="rgba(255,255,255,0.30)" />
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    gap: 14,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    paddingHorizontal: 4,
+  },
+  statBlock: {
+    alignItems: 'flex-start',
+    gap: 1,
+  },
+  statValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.6,
+    fontVariant: ['tabular-nums'],
+  },
+  statValueWarn: {
+    color: '#fbbf24',
+  },
+  statLabel: {
+    fontSize: 9.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+  },
+  statDivider: {
+    width: 1,
+    height: 28,
+    backgroundColor: 'rgba(255,255,255,0.08)',
+  },
+
+  disciplineRow: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+  },
+  discChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 9,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 9,
+    borderWidth: 1,
+    minWidth: 150,
+  },
+  discCodeWrap: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  discCode: {
+    fontSize: 11.5,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  discBody: {
+    flex: 1,
+    gap: 1,
+  },
+  discLabel: {
+    fontSize: 11.5,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  discCount: {
+    fontSize: 10,
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+  },
+
+  listHeader: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 10,
+    paddingHorizontal: 4,
+  },
+  listHeaderText: {
+    fontSize: 9.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.62)',
+    letterSpacing: 1.4,
+  },
+  listHeaderHint: {
+    flex: 1,
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.40)',
+    letterSpacing: -0.05,
+  },
+
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    gap: 6,
+    paddingBottom: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    borderRadius: 9,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.05)',
+  },
+  rowIdx: {
+    width: 28,
+    alignItems: 'center',
+  },
+  rowIdxText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.45)',
+    fontVariant: ['tabular-nums'],
+  },
+  rowDisc: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowDiscText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.42)',
+  },
+  rowBody: {
+    flex: 1,
+    gap: 1,
+  },
+  rowSheetNo: {
+    fontSize: 12.5,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  rowSheetId: {
+    fontSize: 10,
+    color: 'rgba(255,255,255,0.40)',
+    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }) as any,
+    letterSpacing: -0.1,
+  },
+  rowMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+});

--- a/components/service-hub/estimate-studio/plans-photos/UploadDropZone.tsx
+++ b/components/service-hub/estimate-studio/plans-photos/UploadDropZone.tsx
@@ -1,0 +1,494 @@
+/**
+ * UploadDropZone — Wave 6A.
+ *
+ * Production drop zone for the Plans & Photos tab:
+ *   - Drag-drop (PDF / JPG / PNG / HEIC up to 50 MB)
+ *   - Clipboard paste (image data via onPaste)
+ *   - Native file picker fallback (hidden <input type="file" />)
+ *   - Real-time read + upload progress
+ *   - Hard size cap, fail-closed with a clear error
+ *
+ * Mission rule: make complicated blueprints feel simple. Empty hero copy
+ * promises "drop a plan set — we'll read it and tell you the story."
+ *
+ * Premium UX:
+ *   - 200ms cross-fade between idle / uploading / success / error states
+ *   - Drag-over highlight (border + tint)
+ *   - CLS = 0: host card is always full-height
+ *
+ * Mobile + iOS / Android note: drag-drop is web-only; on native this
+ * component still renders and routes through the native file picker.
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type GestureResponderEvent,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  MAX_UPLOAD_BYTES,
+  ACCEPTED_MIME_TYPES,
+} from '@/lib/api/blueprintsApi';
+import { UploadProgressInline } from './UploadProgressInline';
+import type { UploadPhase, UploadProgress } from '@/hooks/useBlueprintUpload';
+import type { StageProgress } from '@/lib/api/blueprintsApi';
+
+const ACCEPT_ATTR = ACCEPTED_MIME_TYPES.join(',');
+
+interface Props {
+  phase: UploadPhase;
+  progress: UploadProgress;
+  filename: string | null;
+  stageProgress: StageProgress;
+  error: { code: string; message: string } | null;
+  onFile: (file: File) => void;
+  onReset: () => void;
+}
+
+function _formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function UploadDropZone({
+  phase,
+  progress,
+  filename,
+  stageProgress,
+  error,
+  onFile,
+  onReset,
+}: Props): React.ReactElement {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+
+  // 200ms cross-fade whenever the phase swaps to a new visual state.
+  useEffect(() => {
+    Animated.sequence([
+      Animated.timing(fadeAnim, { toValue: 0.6, duration: 100, useNativeDriver: true }),
+      Animated.timing(fadeAnim, { toValue: 1, duration: 100, useNativeDriver: true }),
+    ]).start();
+  }, [phase, fadeAnim]);
+
+  const openPicker = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onFile(file);
+      // Reset so re-selecting the same file refires onchange.
+      if (inputRef.current) inputRef.current.value = '';
+    },
+    [onFile],
+  );
+
+  // Web-only drag-drop / paste handlers attached via direct DOM (React Native
+  // Web's drag events are not 1:1 with browser DnD).
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof document === 'undefined') return;
+    const el = document.getElementById('plans-photos-dropzone');
+    if (!el) return;
+
+    const onDragOver = (e: DragEvent): void => {
+      e.preventDefault();
+      setIsDragOver(true);
+    };
+    const onDragLeave = (e: DragEvent): void => {
+      e.preventDefault();
+      setIsDragOver(false);
+    };
+    const onDrop = (e: DragEvent): void => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer?.files?.[0];
+      if (file) onFile(file);
+    };
+    const onPaste = (e: ClipboardEvent): void => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind === 'file') {
+          const file = item.getAsFile();
+          if (file) {
+            onFile(file);
+            return;
+          }
+        }
+      }
+    };
+
+    el.addEventListener('dragover', onDragOver);
+    el.addEventListener('dragleave', onDragLeave);
+    el.addEventListener('drop', onDrop);
+    document.addEventListener('paste', onPaste);
+    return () => {
+      el.removeEventListener('dragover', onDragOver);
+      el.removeEventListener('dragleave', onDragLeave);
+      el.removeEventListener('drop', onDrop);
+      document.removeEventListener('paste', onPaste);
+    };
+  }, [onFile]);
+
+  const handlePressClick = useCallback(
+    (_e: GestureResponderEvent) => {
+      if (phase === 'success' || phase === 'error') {
+        onReset();
+        // Open picker after reset so users can immediately pick a new file.
+        setTimeout(openPicker, 0);
+        return;
+      }
+      openPicker();
+    },
+    [openPicker, onReset, phase],
+  );
+
+  const view = useMemo(() => {
+    if (phase === 'success') {
+      return (
+        <View style={styles.body} testID="dropzone-success">
+          <View style={styles.iconCircleSuccess}>
+            <Ionicons name="checkmark" size={36} color="#22c55e" />
+          </View>
+          <Text style={styles.title}>{filename ?? 'Plan set uploaded'}</Text>
+          <Text style={styles.subtitle}>Drew read the file and tagged the sheets.</Text>
+          <UploadProgressInline stages={stageProgress} layout="horizontal" />
+          <Pressable
+            onPress={() => {
+              onReset();
+              setTimeout(openPicker, 0);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Upload another plan set"
+            style={({ hovered, pressed }: any) => [
+              styles.secondaryButton,
+              hovered && styles.secondaryButtonHover,
+              pressed && styles.secondaryButtonPressed,
+            ]}
+            testID="dropzone-upload-another"
+          >
+            <Ionicons name="cloud-upload-outline" size={14} color="rgba(255,255,255,0.85)" />
+            <Text style={styles.secondaryButtonText}>Upload another</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    if (phase === 'error') {
+      return (
+        <View style={styles.body} testID="dropzone-error">
+          <View style={styles.iconCircleError}>
+            <Ionicons name="alert-circle" size={32} color="#ef4444" />
+          </View>
+          <Text style={styles.title}>Couldn’t process that file</Text>
+          <Text style={styles.subtitle} numberOfLines={3}>
+            {error?.message ?? 'Unknown error.'}
+          </Text>
+          {error?.code ? <Text style={styles.errorCode}>{error.code}</Text> : null}
+          <Pressable
+            onPress={() => {
+              onReset();
+              setTimeout(openPicker, 0);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Try uploading again"
+            style={({ hovered, pressed }: any) => [
+              styles.secondaryButton,
+              hovered && styles.secondaryButtonHover,
+              pressed && styles.secondaryButtonPressed,
+            ]}
+            testID="dropzone-try-again"
+          >
+            <Ionicons name="refresh" size={14} color="rgba(255,255,255,0.85)" />
+            <Text style={styles.secondaryButtonText}>Try again</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    if (phase === 'reading' || phase === 'uploading' || phase === 'ingesting' || phase === 'classifying') {
+      const pct = Math.min(100, Math.max(0, Math.round(progress.ratio * 100)));
+      const phaseLabel: Record<typeof phase, string> = {
+        reading: 'Reading file…',
+        uploading: 'Uploading…',
+        ingesting: 'Drew is parsing the plan set…',
+        classifying: 'Tagging disciplines…',
+      } as const;
+      return (
+        <View style={styles.body} testID={`dropzone-${phase}`}>
+          <View style={styles.iconCircleBusy}>
+            <Ionicons name="sync" size={32} color="#fbbf24" />
+          </View>
+          <Text style={styles.title}>{filename ?? 'Working on it…'}</Text>
+          <Text style={styles.subtitle}>{phaseLabel[phase]}</Text>
+          <View style={styles.progressTrack}>
+            <View
+              style={[
+                styles.progressFill,
+                {
+                  width:
+                    phase === 'reading' || phase === 'uploading'
+                      ? `${pct}%`
+                      : phase === 'ingesting'
+                        ? '66%'
+                        : '92%',
+                },
+              ]}
+            />
+          </View>
+          <Text style={styles.progressLabel}>
+            {phase === 'reading' || phase === 'uploading'
+              ? `${_formatBytes(progress.bytesDone)} / ${_formatBytes(progress.bytesTotal)}`
+              : 'Hold tight — Drew is still working.'}
+          </Text>
+          <UploadProgressInline stages={stageProgress} layout="horizontal" />
+        </View>
+      );
+    }
+
+    // idle
+    return (
+      <View style={styles.body} testID="dropzone-idle">
+        <View style={styles.iconCircleIdle}>
+          <Ionicons name="cloud-upload-outline" size={36} color="rgba(255,255,255,0.85)" />
+        </View>
+        <Text style={styles.title}>Drop a plan set here</Text>
+        <Text style={styles.subtitle}>
+          We’ll read it and tell you the story — sheets, disciplines, revisions.
+        </Text>
+        <Pressable
+          onPress={handlePressClick}
+          accessibilityRole="button"
+          accessibilityLabel="Choose a file to upload"
+          style={({ hovered, pressed }: any) => [
+            styles.primaryButton,
+            hovered && styles.primaryButtonHover,
+            pressed && styles.primaryButtonPressed,
+          ]}
+          testID="dropzone-choose-file"
+        >
+          <Ionicons name="folder-open-outline" size={14} color="#0a0a0a" />
+          <Text style={styles.primaryButtonText}>Choose a file</Text>
+        </Pressable>
+        <Text style={styles.hint}>
+          PDF, JPG, PNG, HEIC — up to {Math.floor(MAX_UPLOAD_BYTES / 1024 / 1024)} MB. Paste from
+          clipboard works too.
+        </Text>
+      </View>
+    );
+  }, [phase, progress, filename, stageProgress, error, handlePressClick, onReset, openPicker]);
+
+  return (
+    <Pressable
+      onPress={phase === 'idle' ? openPicker : undefined}
+      // Keep the host pressable only in idle so success / error CTAs win over it.
+      style={({ hovered }: any) => [
+        styles.host,
+        isDragOver && styles.hostDragOver,
+        hovered && phase === 'idle' && styles.hostHover,
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel="Blueprint upload drop zone"
+      testID="upload-drop-zone"
+      // RN-web sets `id` on the underlying div via nativeID.
+      nativeID="plans-photos-dropzone"
+    >
+      <Animated.View style={[styles.fader, { opacity: fadeAnim }]}>{view}</Animated.View>
+      {Platform.OS === 'web' ? (
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPT_ATTR}
+          style={styles.hiddenInput as any}
+          onChange={handleInputChange}
+          data-testid="dropzone-file-input"
+        />
+      ) : null}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    minHeight: 320,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: 'rgba(255,255,255,0.18)',
+    backgroundColor: 'rgba(255,255,255,0.018)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 28,
+    ...(Platform.OS === 'web'
+      ? ({ transition: 'background-color 200ms ease, border-color 200ms ease' } as any)
+      : {}),
+  },
+  hostHover: {
+    backgroundColor: 'rgba(255,255,255,0.035)',
+    borderColor: 'rgba(255,255,255,0.28)',
+  },
+  hostDragOver: {
+    backgroundColor: 'rgba(251,191,36,0.05)',
+    borderColor: 'rgba(251,191,36,0.65)',
+    borderStyle: 'solid',
+  },
+  fader: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  body: {
+    alignItems: 'center',
+    gap: 14,
+    maxWidth: 460,
+  },
+  iconCircleIdle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+  },
+  iconCircleBusy: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(251,191,36,0.08)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.30)',
+  },
+  iconCircleSuccess: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(34,197,94,0.10)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(34,197,94,0.45)',
+  },
+  iconCircleError: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(239,68,68,0.10)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(239,68,68,0.40)',
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.3,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.65)',
+    textAlign: 'center',
+    lineHeight: 19,
+    letterSpacing: -0.1,
+  },
+  hint: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.40)',
+    textAlign: 'center',
+    letterSpacing: -0.05,
+  },
+  errorCode: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(239,68,68,0.70)',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  primaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#fbbf24',
+    marginTop: 4,
+  },
+  primaryButtonHover: {
+    backgroundColor: '#fcd34d',
+  },
+  primaryButtonPressed: {
+    opacity: 0.9,
+  },
+  primaryButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#0a0a0a',
+    letterSpacing: -0.1,
+  },
+  secondaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 7,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.12)',
+    marginTop: 2,
+  },
+  secondaryButtonHover: {
+    backgroundColor: 'rgba(255,255,255,0.08)',
+  },
+  secondaryButtonPressed: {
+    opacity: 0.85,
+  },
+  secondaryButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.05,
+  },
+  progressTrack: {
+    width: '100%',
+    maxWidth: 320,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 3,
+    backgroundColor: '#fbbf24',
+    ...(Platform.OS === 'web' ? ({ transition: 'width 200ms ease' } as any) : {}),
+  },
+  progressLabel: {
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.05,
+  },
+  hiddenInput: {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+    opacity: 0,
+    pointerEvents: 'none',
+  },
+});

--- a/components/service-hub/estimate-studio/plans-photos/UploadProgressInline.tsx
+++ b/components/service-hub/estimate-studio/plans-photos/UploadProgressInline.tsx
@@ -1,0 +1,141 @@
+/**
+ * UploadProgressInline — Wave 6A.
+ *
+ * 5-stage pipeline indicator that lives INSIDE the Plans & Photos canvas
+ * (independent of Tim Rail — no Tim dependency). The same component renders
+ * inline (horizontal) OR in the Tim Rail Context payload (vertical) via the
+ * `layout` prop.
+ *
+ * Wave 6A reality: only `ingest` and `classify` carry real state. SEE /
+ * REASON / PROCURE pills are STRUCTURAL PLACEHOLDERS so the UI is shaped
+ * correctly for Wave 3/4/5. The wave-coming-soon banner above explains this
+ * to localhost reviewers.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { StageKey, StageStatus, StageProgress } from '@/lib/api/blueprintsApi';
+
+interface Props {
+  stages: StageProgress;
+  layout?: 'horizontal' | 'vertical';
+  testID?: string;
+}
+
+const STAGE_ORDER: ReadonlyArray<{ key: StageKey; label: string; shortLabel: string }> = [
+  { key: 'ingest', label: 'Ingest', shortLabel: 'INGEST' },
+  { key: 'classify', label: 'Classify', shortLabel: 'CLASSIFY' },
+  { key: 'see', label: 'See', shortLabel: 'SEE' },
+  { key: 'reason', label: 'Reason', shortLabel: 'REASON' },
+  { key: 'procure', label: 'Procure', shortLabel: 'PROCURE' },
+];
+
+function _statusGlyph(status: StageStatus): {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  color: string;
+} {
+  switch (status) {
+    case 'ok':
+      return { icon: 'checkmark-circle', color: '#22c55e' };
+    case 'running':
+      return { icon: 'sync', color: '#fbbf24' };
+    case 'error':
+      return { icon: 'alert-circle', color: '#ef4444' };
+    case 'stub':
+      return { icon: 'time-outline', color: 'rgba(255,255,255,0.35)' };
+    case 'pending':
+    default:
+      return { icon: 'ellipse-outline', color: 'rgba(255,255,255,0.30)' };
+  }
+}
+
+export function UploadProgressInline({
+  stages,
+  layout = 'horizontal',
+  testID,
+}: Props): React.ReactElement {
+  const isVertical = layout === 'vertical';
+  return (
+    <View
+      style={[styles.host, isVertical ? styles.hostVertical : styles.hostHorizontal]}
+      testID={testID ?? 'upload-progress-inline'}
+      accessibilityLabel="Blueprint pipeline progress"
+    >
+      {STAGE_ORDER.map((stage, idx) => {
+        const status: StageStatus = stages[stage.key];
+        const glyph = _statusGlyph(status);
+        const isLast = idx === STAGE_ORDER.length - 1;
+        // SEE/REASON/PROCURE are Wave 3/4/5 — dim them slightly so the eye
+        // tracks the active stages.
+        const isFuture = stage.key === 'see' || stage.key === 'reason' || stage.key === 'procure';
+
+        return (
+          <React.Fragment key={stage.key}>
+            <View
+              style={[
+                styles.pill,
+                isVertical ? styles.pillVertical : styles.pillHorizontal,
+                isFuture && styles.pillFuture,
+              ]}
+              testID={`upload-progress-pill-${stage.key}`}
+            >
+              <Ionicons name={glyph.icon} size={isVertical ? 14 : 13} color={glyph.color} />
+              <Text style={[styles.pillLabel, isFuture && styles.pillLabelFuture]}>
+                {isVertical ? stage.label : stage.shortLabel}
+              </Text>
+            </View>
+            {!isLast && !isVertical ? <View style={styles.connector} /> : null}
+          </React.Fragment>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    gap: 6,
+  },
+  hostHorizontal: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  hostVertical: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    borderRadius: 7,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  pillHorizontal: {},
+  pillVertical: {
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  pillFuture: {
+    opacity: 0.65,
+  },
+  pillLabel: {
+    fontSize: 10.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.82)',
+    letterSpacing: 0.6,
+  },
+  pillLabelFuture: {
+    color: 'rgba(255,255,255,0.55)',
+  },
+  connector: {
+    width: 14,
+    height: 1,
+    backgroundColor: 'rgba(255,255,255,0.08)',
+  },
+});

--- a/components/service-hub/estimate-studio/plans-photos/disciplines.ts
+++ b/components/service-hub/estimate-studio/plans-photos/disciplines.ts
@@ -1,0 +1,68 @@
+/**
+ * Discipline color map for blueprint sheet chips.
+ *
+ * Sheet disciplines follow AIA convention (A/S/M/E/P/FP/C/L/Specs/Schedules
+ * /Addenda). Each gets a distinct hue so the roster + thumbnails
+ * (Wave 6.5) are scannable at a glance.
+ *
+ * The Drew CLASSIFY response (Wave 2A) returns `discipline_counts` as a
+ * Record<string, number>. Unknown disciplines fall back to a neutral gray.
+ */
+
+export interface DisciplineStyle {
+  /** Discipline key the chip displays — single uppercase letter or short code. */
+  code: string;
+  /** Full label for tooltips / a11y. */
+  label: string;
+  /** Dim background fill (rgba). */
+  bg: string;
+  /** Bright accent border/text color. */
+  fg: string;
+}
+
+const STYLES: Record<string, DisciplineStyle> = {
+  architectural: { code: 'A', label: 'Architectural', bg: 'rgba(251,191,36,0.10)', fg: '#fbbf24' },
+  structural: { code: 'S', label: 'Structural', bg: 'rgba(239,68,68,0.10)', fg: '#ef4444' },
+  mechanical: { code: 'M', label: 'Mechanical', bg: 'rgba(20,184,166,0.10)', fg: '#14b8a6' },
+  electrical: { code: 'E', label: 'Electrical', bg: 'rgba(168,85,247,0.10)', fg: '#a855f7' },
+  plumbing: { code: 'P', label: 'Plumbing', bg: 'rgba(59,130,246,0.10)', fg: '#3b82f6' },
+  fire_protection: { code: 'FP', label: 'Fire Protection', bg: 'rgba(244,114,182,0.10)', fg: '#f472b6' },
+  civil: { code: 'C', label: 'Civil', bg: 'rgba(132,204,22,0.10)', fg: '#84cc16' },
+  landscape: { code: 'L', label: 'Landscape', bg: 'rgba(34,197,94,0.10)', fg: '#22c55e' },
+  specifications: { code: 'SP', label: 'Specifications', bg: 'rgba(148,163,184,0.10)', fg: '#94a3b8' },
+  schedules: { code: 'SC', label: 'Schedules', bg: 'rgba(251,146,60,0.10)', fg: '#fb923c' },
+  addenda: { code: 'AD', label: 'Addenda', bg: 'rgba(217,70,239,0.10)', fg: '#d946ef' },
+};
+
+const FALLBACK: DisciplineStyle = {
+  code: '?',
+  label: 'Unclassified',
+  bg: 'rgba(255,255,255,0.04)',
+  fg: 'rgba(255,255,255,0.55)',
+};
+
+/** Resolve a discipline label (any case, spaces or underscores) to its style. */
+export function getDisciplineStyle(discipline: string | null | undefined): DisciplineStyle {
+  if (!discipline) return FALLBACK;
+  const key = discipline.toLowerCase().replace(/\s+/g, '_').replace(/-/g, '_');
+  return STYLES[key] ?? {
+    ...FALLBACK,
+    code: discipline.slice(0, 2).toUpperCase(),
+    label: discipline,
+  };
+}
+
+/** All known disciplines, in display order. */
+export const KNOWN_DISCIPLINES: ReadonlyArray<keyof typeof STYLES> = [
+  'architectural',
+  'structural',
+  'mechanical',
+  'electrical',
+  'plumbing',
+  'fire_protection',
+  'civil',
+  'landscape',
+  'specifications',
+  'schedules',
+  'addenda',
+] as const;

--- a/components/service-hub/estimate-studio/shell/BottomChipStrip.tsx
+++ b/components/service-hub/estimate-studio/shell/BottomChipStrip.tsx
@@ -1,0 +1,201 @@
+/**
+ * BottomChipStrip — Wave 6A shared shell.
+ *
+ * Horizontal scroll strip of 4–6 "card chips". Each chip is a flat-premium
+ * card geometry (icon + title + optional 1-line stat + optional status
+ * badge). Clicking a chip swaps the active card in <CanvasCardSwitcher />.
+ *
+ * Visual reference: Service Studio bottom-row card chips ("Local Leads
+ * Coverage", "Routing & Follow-up", etc.) — premium dark fills with
+ * yellow-edge accent on the selected chip.
+ *
+ * Used by:
+ *   - Wave 6A: PlansPhotosTab (Upload / Sheets / Disciplines / Revisions).
+ *   - Wave 7+: Scope, Takeoff tabs reuse the same strip.
+ */
+import React from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export interface BottomChip<K extends string> {
+  key: K;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+  /** One-line stat or count, e.g. "14 sheets" or "Ingesting…". */
+  stat?: string;
+  /** Tiny badge text, e.g. "(14)" or "REV 2". */
+  badge?: string;
+  disabled?: boolean;
+}
+
+interface Props<K extends string> {
+  chips: BottomChip<K>[];
+  activeKey: K;
+  onChange: (key: K) => void;
+  testID?: string;
+}
+
+export function BottomChipStrip<K extends string>({
+  chips,
+  activeKey,
+  onChange,
+  testID,
+}: Props<K>): React.ReactElement {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={styles.strip}
+      contentContainerStyle={styles.stripContent}
+      testID={testID ?? 'bottom-chip-strip'}
+    >
+      {chips.map((chip) => {
+        const isActive = chip.key === activeKey;
+        const isDisabled = !!chip.disabled;
+        return (
+          <Pressable
+            key={chip.key}
+            disabled={isDisabled}
+            onPress={() => onChange(chip.key)}
+            accessibilityRole="button"
+            accessibilityLabel={`${chip.label}${chip.stat ? ` — ${chip.stat}` : ''}`}
+            accessibilityState={{ selected: isActive, disabled: isDisabled }}
+            testID={`bottom-chip-${chip.key}`}
+            style={({ hovered, pressed }: { hovered?: boolean; pressed: boolean }) => [
+              styles.chip,
+              isActive && styles.chipActive,
+              isDisabled && styles.chipDisabled,
+              hovered && !isActive && !isDisabled && styles.chipHover,
+              pressed && !isDisabled && styles.chipPressed,
+            ]}
+          >
+            <View style={styles.chipIconWrap}>
+              <Ionicons
+                name={chip.icon}
+                size={16}
+                color={
+                  isDisabled
+                    ? 'rgba(255,255,255,0.30)'
+                    : isActive
+                      ? '#fbbf24'
+                      : 'rgba(255,255,255,0.78)'
+                }
+              />
+            </View>
+            <View style={styles.chipBody}>
+              <View style={styles.chipTitleRow}>
+                <Text
+                  style={[
+                    styles.chipLabel,
+                    isActive && styles.chipLabelActive,
+                    isDisabled && styles.chipLabelDisabled,
+                  ]}
+                  numberOfLines={1}
+                >
+                  {chip.label}
+                </Text>
+                {chip.badge ? (
+                  <Text style={[styles.chipBadge, isActive && styles.chipBadgeActive]}>
+                    {chip.badge}
+                  </Text>
+                ) : null}
+              </View>
+              {chip.stat ? (
+                <Text
+                  style={[styles.chipStat, isActive && styles.chipStatActive]}
+                  numberOfLines={1}
+                >
+                  {chip.stat}
+                </Text>
+              ) : null}
+            </View>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  strip: {
+    flexGrow: 0,
+  },
+  stripContent: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 4,
+    paddingVertical: 8,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    minWidth: 150,
+    maxWidth: 220,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    ...(Platform.OS === 'web'
+      ? ({ transition: 'background-color 150ms ease, border-color 150ms ease' } as any)
+      : {}),
+  },
+  chipActive: {
+    backgroundColor: 'rgba(251,191,36,0.08)',
+    borderColor: 'rgba(251,191,36,0.55)',
+  },
+  chipHover: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    borderColor: 'rgba(255,255,255,0.14)',
+  },
+  chipPressed: {
+    opacity: 0.85,
+  },
+  chipDisabled: {
+    opacity: 0.4,
+  },
+  chipIconWrap: {
+    width: 22,
+    alignItems: 'center',
+  },
+  chipBody: {
+    flex: 1,
+    gap: 2,
+  },
+  chipTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  chipLabel: {
+    fontSize: 12.5,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.1,
+  },
+  chipLabelActive: {
+    color: '#fbbf24',
+  },
+  chipLabelDisabled: {
+    color: 'rgba(255,255,255,0.48)',
+  },
+  chipBadge: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+  },
+  chipBadgeActive: {
+    color: 'rgba(251,191,36,0.85)',
+  },
+  chipStat: {
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+  },
+  chipStatActive: {
+    color: 'rgba(251,191,36,0.72)',
+  },
+});

--- a/components/service-hub/estimate-studio/shell/CanvasCardSwitcher.tsx
+++ b/components/service-hub/estimate-studio/shell/CanvasCardSwitcher.tsx
@@ -1,0 +1,77 @@
+/**
+ * CanvasCardSwitcher — Wave 6A shared shell.
+ *
+ * Hosts exactly ONE big "canvas card" at a time. When `activeCardKey`
+ * changes, the previously-active card cross-fades out and the new one
+ * fades in over 200ms (CLS=0 — the host card slot is always reserved
+ * full-height so layout never shifts).
+ *
+ * Used by:
+ *   - Wave 6A: PlansPhotosTab (Upload / Sheets / Disciplines / Revisions).
+ *   - Wave 7+: Scope, Takeoff tabs follow the same shell pattern.
+ *
+ * Premium UX (per feedback_premium_seamless):
+ *   - CLS = 0
+ *   - 200ms cross-fade between cards
+ *   - Identical card geometry per card slot (consumers control inner content)
+ *
+ * Law #7: render layer only — no autonomous decisions.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+
+interface Props<K extends string> {
+  /** Which card is currently visible. */
+  activeCardKey: K;
+  /** Map of card key → ReactNode. Unknown keys render nothing (fail-closed). */
+  cards: Record<K, React.ReactNode>;
+  /** Cross-fade duration in ms (default 200, matches premium-seamless lock). */
+  fadeMs?: number;
+  testID?: string;
+}
+
+export function CanvasCardSwitcher<K extends string>({
+  activeCardKey,
+  cards,
+  fadeMs = 200,
+  testID,
+}: Props<K>): React.ReactElement {
+  const [displayedKey, setDisplayedKey] = useState<K>(activeCardKey);
+  const opacity = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (activeCardKey === displayedKey) return;
+
+    // Fade out current → swap → fade in new.
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: fadeMs / 2,
+      useNativeDriver: true,
+    }).start(() => {
+      setDisplayedKey(activeCardKey);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: fadeMs / 2,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [activeCardKey, displayedKey, fadeMs, opacity]);
+
+  const visibleCard = cards[displayedKey] ?? null;
+
+  return (
+    <View style={styles.host} testID={testID ?? 'canvas-card-switcher'}>
+      <Animated.View style={[styles.cardSlot, { opacity }]}>{visibleCard}</Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    minHeight: 320,
+  },
+  cardSlot: {
+    flex: 1,
+  },
+});

--- a/components/service-hub/estimate-studio/shell/ContextTabPayload.tsx
+++ b/components/service-hub/estimate-studio/shell/ContextTabPayload.tsx
@@ -1,0 +1,78 @@
+/**
+ * ContextTabPayload — Wave 6A shared shell.
+ *
+ * Generic per-tab payload host that extends the Tim Rail Context tab. The
+ * Context tab itself stays a single column; per-tab content is injected
+ * via this component as a list of titled sections.
+ *
+ * Used by:
+ *   - Wave 6A: PlansPhotosTab payload (pipeline status, discipline counts,
+ *     last upload, revision activity).
+ *   - Wave 7+: Scope, Takeoff, Estimate tabs each pass their own sections.
+ *
+ * Law #7: pure render — no fetch, no decision.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export interface ContextSection {
+  /** Stable key for React. */
+  key: string;
+  /** Section title (small caps tracking, like the rest of the rail). */
+  title: string;
+  /** Optional one-line subtitle under the title. */
+  subtitle?: string;
+  /** Section body — anything React-rendered. */
+  render: () => React.ReactNode;
+}
+
+interface Props {
+  sections: ContextSection[];
+  testID?: string;
+}
+
+export function ContextTabPayload({ sections, testID }: Props): React.ReactElement {
+  return (
+    <View style={styles.payload} testID={testID ?? 'context-tab-payload'}>
+      {sections.map((section) => (
+        <View key={section.key} style={styles.section} testID={`context-section-${section.key}`}>
+          <View style={styles.headerRow}>
+            <Text style={styles.sectionTitle}>{section.title}</Text>
+            {section.subtitle ? (
+              <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
+            ) : null}
+          </View>
+          <View style={styles.body}>{section.render()}</View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  payload: {
+    gap: 16,
+  },
+  section: {
+    gap: 8,
+  },
+  headerRow: {
+    gap: 2,
+    paddingHorizontal: 4,
+  },
+  sectionTitle: {
+    fontSize: 9.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.62)',
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+  },
+  sectionSubtitle: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.48)',
+    letterSpacing: -0.05,
+  },
+  body: {
+    gap: 6,
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/PlansPhotosContextPayload.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/PlansPhotosContextPayload.tsx
@@ -1,0 +1,222 @@
+/**
+ * PlansPhotosContextPayload — Wave 6A.
+ *
+ * Tim Rail Context tab payload for the Plans & Photos route. Renders:
+ *   - Pipeline status (vertical 5-stage indicator)
+ *   - Discipline counts (compact chips)
+ *   - Last upload (filename + relative time)
+ *   - Revision activity (count)
+ *
+ * Property facts are NOT rendered here — TimRailContextTab still mounts
+ * the shared <PropertySummaryCard /> below this component.
+ *
+ * Wave 6A reality: ingest + classify carry real data; the remaining 3
+ * stages are dimmed placeholders. The PlansPhotosTab also surfaces a
+ * banner explaining what's coming in Wave 6.5.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useBlueprintUploadSnapshot } from '@/lib/blueprintUploadStore';
+import { ContextTabPayload, type ContextSection } from '../shell/ContextTabPayload';
+import { UploadProgressInline } from '../plans-photos/UploadProgressInline';
+import { getDisciplineStyle } from '../plans-photos/disciplines';
+
+function _relativeTime(ts: number | null): string {
+  if (ts == null) return '—';
+  const delta = Date.now() - ts;
+  if (delta < 60_000) return 'just now';
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return `${Math.floor(delta / 86_400_000)}d ago`;
+}
+
+export function PlansPhotosContextPayload(): React.ReactElement {
+  const snap = useBlueprintUploadSnapshot();
+  const disciplines = Object.entries(snap.response?.classify?.discipline_counts ?? {}).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const sheetCount = snap.response?.ingest.sheet_count ?? 0;
+  const revisions = snap.response?.classify?.revisions ?? 0;
+
+  const sections: ContextSection[] = [
+    {
+      key: 'pipeline',
+      title: 'Pipeline Status',
+      subtitle: 'Wave 6A: Ingest + Classify real · See/Reason/Procure ship in Wave 3+',
+      render: () => (
+        <UploadProgressInline
+          stages={snap.stageProgress}
+          layout="vertical"
+          testID="context-pipeline-status"
+        />
+      ),
+    },
+    {
+      key: 'disciplines',
+      title: 'Discipline Counts',
+      render: () => {
+        if (disciplines.length === 0) {
+          return <Text style={styles.empty}>No classification yet.</Text>;
+        }
+        return (
+          <View style={styles.discWrap}>
+            {disciplines.map(([disc, count]) => {
+              const s = getDisciplineStyle(disc);
+              return (
+                <View
+                  key={disc}
+                  style={[styles.discChip, { backgroundColor: s.bg, borderColor: s.fg + '55' }]}
+                  testID={`context-disc-${disc}`}
+                >
+                  <Text style={[styles.discCode, { color: s.fg }]}>{s.code}</Text>
+                  <Text style={styles.discLabel}>{s.label}</Text>
+                  <Text style={[styles.discCount, { color: s.fg }]}>{count}</Text>
+                </View>
+              );
+            })}
+          </View>
+        );
+      },
+    },
+    {
+      key: 'last-upload',
+      title: 'Last Upload',
+      render: () => (
+        <View style={styles.lastRow} testID="context-last-upload">
+          <Ionicons
+            name="document-attach-outline"
+            size={14}
+            color="rgba(255,255,255,0.55)"
+          />
+          <View style={styles.lastBody}>
+            <Text style={styles.lastFilename} numberOfLines={1}>
+              {snap.filename ?? 'No upload yet'}
+            </Text>
+            <Text style={styles.lastMeta}>
+              {snap.filename
+                ? `${sheetCount} sheet${sheetCount === 1 ? '' : 's'} · ${_relativeTime(snap.uploadedAt)}`
+                : 'Drop a plan set on the canvas.'}
+            </Text>
+          </View>
+        </View>
+      ),
+    },
+    {
+      key: 'revisions',
+      title: 'Revision Activity',
+      render: () => (
+        <View style={styles.revRow} testID="context-revisions">
+          <View style={styles.revStat}>
+            <Text style={styles.revValue}>{revisions}</Text>
+            <Text style={styles.revLabel}>superseded</Text>
+          </View>
+          <Text style={styles.revHint}>
+            {revisions === 0
+              ? 'No revisions detected.'
+              : 'Per-sheet revision chain ships in Wave 6.5.'}
+          </Text>
+        </View>
+      ),
+    },
+  ];
+
+  return <ContextTabPayload sections={sections} testID="plans-photos-context-payload" />;
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.45)',
+    letterSpacing: -0.05,
+    paddingHorizontal: 4,
+  },
+  discWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    paddingHorizontal: 2,
+  },
+  discChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: 1,
+  },
+  discCode: {
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+  },
+  discLabel: {
+    fontSize: 10.5,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.05,
+  },
+  discCount: {
+    fontSize: 10,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  lastRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+  },
+  lastBody: {
+    flex: 1,
+    gap: 2,
+  },
+  lastFilename: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  lastMeta: {
+    fontSize: 10,
+    color: 'rgba(255,255,255,0.50)',
+    letterSpacing: -0.05,
+  },
+  revRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  revStat: {
+    alignItems: 'center',
+    minWidth: 40,
+  },
+  revValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    fontVariant: ['tabular-nums'],
+  },
+  revLabel: {
+    fontSize: 8.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  revHint: {
+    flex: 1,
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.50)',
+    letterSpacing: -0.05,
+    lineHeight: 14,
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
@@ -13,6 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { usePathname } from 'expo-router';
 import { PropertySummaryCard } from './PropertySummaryCard';
 import { MaterialsRouteContextCard } from './MaterialsRouteContextCard';
+import { PlansPhotosContextPayload } from './PlansPhotosContextPayload';
 import type { PropertyData } from '@/services/serviceHub/propertyDataApi';
 
 // Inject a one-shot stylesheet on web that hides the scrollbar inside
@@ -43,6 +44,8 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
   const pathname = usePathname() ?? '';
   const isMaterialsTab =
     pathname.endsWith('/materials') || pathname.endsWith('/materials/');
+  const isPlansPhotosTab =
+    pathname.endsWith('/plans-photos') || pathname.endsWith('/plans-photos/');
 
   return (
     <ScrollView
@@ -84,6 +87,10 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
 
       {/* Materials-tab-only — renders null off-route via context check. */}
       <MaterialsRouteContextCard />
+
+      {/* Plans & Photos payload: pipeline status + discipline counts + last
+          upload. Renders null off-route. Property facts carry over below. */}
+      {isPlansPhotosTab && <PlansPhotosContextPayload />}
 
       {/* Property facts hidden on Materials tab — that tab's context
           is the route + bundle, not the property valuation card. The

--- a/hooks/useBlueprintProject.ts
+++ b/hooks/useBlueprintProject.ts
@@ -1,0 +1,49 @@
+/**
+ * useBlueprintProject — Wave 6.5 STUB.
+ *
+ * Wave 6A leaves this as a thin scaffold so call-sites can import the hook
+ * shape today. The full implementation polls
+ * `GET /api/v1/blueprints/projects/:id/status` at 2s intervals while any
+ * stage is still in-flight, and fans the project + sheets into the rail.
+ *
+ * Backend gap: GET endpoints land in Wave 2.5 (separate backend PR).
+ * Once that ships, this hook gets a real fetch loop + stop-on-complete logic.
+ */
+import { useMemo } from 'react';
+import type { BlueprintProject, BlueprintSheet, StageProgress } from '@/lib/api/blueprintsApi';
+
+export interface UseBlueprintProjectResult {
+  project: BlueprintProject | null;
+  sheets: BlueprintSheet[];
+  stageProgress: StageProgress;
+  isLoading: boolean;
+  error: { code: string; message: string } | null;
+  /** When true, polling will run while stages are in-flight (Wave 6.5). */
+  isPolling: boolean;
+}
+
+const EMPTY_STAGE: StageProgress = {
+  ingest: 'pending',
+  classify: 'pending',
+  see: 'pending',
+  reason: 'pending',
+  procure: 'pending',
+};
+
+/**
+ * Wave 6A: returns an empty shape. Wave 6.5 will replace with a real fetch
+ * + 2s poll loop. `projectId` is accepted today so call-sites typecheck.
+ */
+export function useBlueprintProject(_projectId: string | null): UseBlueprintProjectResult {
+  return useMemo(
+    () => ({
+      project: null,
+      sheets: [],
+      stageProgress: EMPTY_STAGE,
+      isLoading: false,
+      error: null,
+      isPolling: false,
+    }),
+    [],
+  );
+}

--- a/hooks/useBlueprintUpload.ts
+++ b/hooks/useBlueprintUpload.ts
@@ -1,0 +1,285 @@
+/**
+ * useBlueprintUpload — Wave 6A.
+ *
+ * Owns the upload state machine for the Plans & Photos tab:
+ *   idle → reading-file → uploading → ingesting → classifying → success
+ *                                                            ↘ error
+ *
+ * Wave 6A scope:
+ *   - Single-file upload (PDF / JPG / PNG / HEIC, ≤ 50 MB).
+ *   - Reads the File into a Uint8Array, calls `uploadBlueprint()`, surfaces
+ *     real INGEST + CLASSIFY status from the proxy response.
+ *
+ * Wave 6.5+:
+ *   - Polling-based SEE / REASON / PROCURE status (separate hook).
+ *
+ * Law compliance:
+ *   Law #3 — size + MIME validated before upload.
+ *   Law #5 — capability token stays server-side.
+ *   Law #6 — officeId/suiteId come from useTenant().
+ *   Law #9 — file bytes never logged; only filename + size.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuthFetch } from '@/lib/authenticatedFetch';
+import { useTenant } from '@/providers';
+import { setBlueprintUpload, resetBlueprintUpload } from '@/lib/blueprintUploadStore';
+import {
+  uploadBlueprint,
+  BlueprintsApiError,
+  MAX_UPLOAD_BYTES,
+  ACCEPTED_MIME_TYPES,
+  type AcceptedMimeType,
+  type UploadBlueprintResponse,
+  type StageProgress,
+} from '@/lib/api/blueprintsApi';
+
+export type UploadPhase =
+  | 'idle'
+  | 'reading'
+  | 'uploading'
+  | 'ingesting'
+  | 'classifying'
+  | 'success'
+  | 'error';
+
+export interface UploadProgress {
+  /** 0-1 — only meaningful during 'reading' + 'uploading'. */
+  ratio: number;
+  /** Bytes read / sent so far. */
+  bytesDone: number;
+  /** Total bytes to send. */
+  bytesTotal: number;
+}
+
+export interface UseBlueprintUploadResult {
+  phase: UploadPhase;
+  progress: UploadProgress;
+  filename: string | null;
+  response: UploadBlueprintResponse | null;
+  /** Composed 5-stage progress — drives <UploadProgressInline />. Falls back
+   *  to all-pending when no upload has run. */
+  stageProgress: StageProgress;
+  error: { code: string; message: string } | null;
+  upload: (file: File) => Promise<void>;
+  reset: () => void;
+}
+
+const INITIAL_PROGRESS: UploadProgress = { ratio: 0, bytesDone: 0, bytesTotal: 0 };
+const INITIAL_STAGE_PROGRESS: StageProgress = {
+  ingest: 'pending',
+  classify: 'pending',
+  see: 'pending',
+  reason: 'pending',
+  procure: 'pending',
+};
+
+function _validateFile(
+  file: File,
+): { ok: true; mimeType: AcceptedMimeType } | { ok: false; code: string; message: string } {
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return {
+      ok: false,
+      code: 'FILE_TOO_LARGE',
+      message: `File is ${(file.size / 1024 / 1024).toFixed(1)} MB — max is ${(MAX_UPLOAD_BYTES / 1024 / 1024).toFixed(0)} MB.`,
+    };
+  }
+  const type = (file.type || '').toLowerCase();
+  // Some browsers report HEIC as empty; fall back to extension.
+  let mimeType: AcceptedMimeType | null = null;
+  if ((ACCEPTED_MIME_TYPES as readonly string[]).includes(type)) {
+    mimeType = type as AcceptedMimeType;
+  } else {
+    const lower = file.name.toLowerCase();
+    if (lower.endsWith('.pdf')) mimeType = 'application/pdf';
+    else if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) mimeType = 'image/jpeg';
+    else if (lower.endsWith('.png')) mimeType = 'image/png';
+    else if (lower.endsWith('.heic') || lower.endsWith('.heif')) mimeType = 'image/heic';
+  }
+  if (!mimeType) {
+    return {
+      ok: false,
+      code: 'UNSUPPORTED_MEDIA_TYPE',
+      message: 'Only PDF, JPG, PNG, and HEIC files are accepted.',
+    };
+  }
+  return { ok: true, mimeType };
+}
+
+function _readFileWithProgress(
+  file: File,
+  onProgress: (loaded: number, total: number) => void,
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onprogress = (e) => {
+      if (e.lengthComputable) onProgress(e.loaded, e.total);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'));
+    reader.onload = () => {
+      const buf = reader.result;
+      if (buf instanceof ArrayBuffer) resolve(new Uint8Array(buf));
+      else reject(new Error('FileReader returned non-ArrayBuffer'));
+    };
+    reader.readAsArrayBuffer(file);
+  });
+}
+
+export function useBlueprintUpload(): UseBlueprintUploadResult {
+  const { authenticatedFetch } = useAuthFetch();
+  // Note: mirrors useMaterialsSearch.ts — `officeId` is part of the Tenant
+  // payload at runtime but isn't exposed on the TenantContextType interface
+  // (pre-existing typing gap, see useMaterialsSearch:269). Same `as any`
+  // shape; the runtime value is read correctly.
+  const tenant = useTenant() as { officeId?: string };
+  const officeId = tenant.officeId ?? '';
+
+  const [phase, setPhase] = useState<UploadPhase>('idle');
+  const [progress, setProgress] = useState<UploadProgress>(INITIAL_PROGRESS);
+  const [filename, setFilename] = useState<string | null>(null);
+  const [response, setResponse] = useState<UploadBlueprintResponse | null>(null);
+  const [stageProgress, setStageProgress] = useState<StageProgress>(INITIAL_STAGE_PROGRESS);
+  const [error, setError] = useState<{ code: string; message: string } | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Publish state changes to the module-level store so the Tim Rail Context
+  // tab can observe them without a provider.
+  useEffect(() => {
+    setBlueprintUpload({
+      phase,
+      filename,
+      response,
+      stageProgress,
+      error,
+      uploadedAt: phase === 'success' ? Date.now() : null,
+    });
+  }, [phase, filename, response, stageProgress, error]);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setPhase('idle');
+    setProgress(INITIAL_PROGRESS);
+    setFilename(null);
+    setResponse(null);
+    setStageProgress(INITIAL_STAGE_PROGRESS);
+    setError(null);
+    resetBlueprintUpload();
+  }, []);
+
+  const upload = useCallback(
+    async (file: File) => {
+      // Reset prior state but keep `filename` showing immediately for premium UX.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setFilename(file.name);
+      setError(null);
+      setResponse(null);
+
+      const validation = _validateFile(file);
+      if (!validation.ok) {
+        setPhase('error');
+        setError({ code: validation.code, message: validation.message });
+        return;
+      }
+
+      // ── reading ──
+      setPhase('reading');
+      setProgress({ ratio: 0, bytesDone: 0, bytesTotal: file.size });
+      let bytes: Uint8Array;
+      try {
+        bytes = await _readFileWithProgress(file, (loaded, total) => {
+          setProgress({ ratio: total > 0 ? loaded / total : 0, bytesDone: loaded, bytesTotal: total });
+        });
+      } catch (err) {
+        setPhase('error');
+        setError({
+          code: 'FILE_READ_FAILED',
+          message: err instanceof Error ? err.message : 'Could not read file.',
+        });
+        return;
+      }
+
+      // ── uploading → ingesting → classifying (server-side chain) ──
+      setPhase('uploading');
+      setProgress({ ratio: 1, bytesDone: bytes.byteLength, bytesTotal: bytes.byteLength });
+      setStageProgress({
+        ingest: 'running',
+        classify: 'pending',
+        see: 'pending',
+        reason: 'pending',
+        procure: 'pending',
+      });
+
+      // The proxy returns a single response once both INGEST + CLASSIFY are done.
+      // We hop the phase to 'ingesting' immediately for UX (a true in-flight
+      // INGEST is what the server is doing for ~70% of total time per Drew
+      // Wave 2A timings) and let `setStageProgress` resolve the final state.
+      setPhase('ingesting');
+
+      try {
+        const result = await uploadBlueprint(authenticatedFetch, {
+          fileBytes: bytes,
+          filename: file.name,
+          mimeType: validation.mimeType,
+          officeId: officeId,
+          signal: controller.signal,
+        });
+
+        // Drew may return status:'error' inline (HTTP 200) for in-band failures
+        // like missing payload keys; treat that as terminal here.
+        if (result.ingest.status === 'error') {
+          setStageProgress({
+            ingest: 'error',
+            classify: 'pending',
+            see: 'pending',
+            reason: 'pending',
+            procure: 'pending',
+          });
+          setPhase('error');
+          setError({
+            code: 'INGEST_FAILED',
+            message: result.ingest.reason ?? 'Ingest step failed.',
+          });
+          return;
+        }
+
+        setPhase('classifying');
+        setStageProgress(result.stage_progress);
+        setResponse(result);
+        setPhase('success');
+      } catch (err) {
+        if (controller.signal.aborted) {
+          // Caller hit reset() — already cleared via reset; do nothing.
+          return;
+        }
+        if (err instanceof BlueprintsApiError) {
+          setStageProgress((prev) => ({ ...prev, ingest: 'error' }));
+          setPhase('error');
+          setError({ code: err.code, message: err.message });
+        } else {
+          setStageProgress((prev) => ({ ...prev, ingest: 'error' }));
+          setPhase('error');
+          setError({
+            code: 'NETWORK_ERROR',
+            message: err instanceof Error ? err.message : 'Network error.',
+          });
+        }
+      }
+    },
+    [authenticatedFetch, officeId],
+  );
+
+  return {
+    phase,
+    progress,
+    filename,
+    response,
+    stageProgress,
+    error,
+    upload,
+    reset,
+  };
+}

--- a/lib/api/blueprintsApi.ts
+++ b/lib/api/blueprintsApi.ts
@@ -1,0 +1,288 @@
+/**
+ * Blueprints API client — Wave 6A (Plans & Photos production upload).
+ *
+ * Wraps `POST /api/v1/blueprints/upload` (Express proxy that mints a
+ * capability token + forwards to Drew via the Python orchestrator's
+ * `/v1/agents/invoke` endpoint).
+ *
+ * Wave 6A scope:
+ *   - uploadBlueprint(): full INGEST + auto-chained CLASSIFY in one call.
+ *
+ * Wave 6.5 (deferred — backend GET endpoints not yet wired):
+ *   - getProject(): GET /api/v1/blueprints/projects/:id
+ *   - listSheets(): GET /api/v1/blueprints/projects/:id/sheets
+ *   - getProjectStatus(): GET /api/v1/blueprints/projects/:id/status
+ *
+ * These three are declared with their full types so call-sites can be
+ * sketched ahead of Wave 6.5 wiring, but the implementations throw
+ * `NotImplementedError` until the backend reads land. See
+ * docs/plans/serene-seeking-hollerith for the cross-wave plan.
+ *
+ * Law compliance:
+ *   Law #5 — capability token minted server-side by the Express proxy.
+ *   Law #6 — suite_id derives from authenticated session; client never sets it.
+ *   Law #3 — 50 MB file cap enforced client + server side (fail-closed).
+ *   Law #9 — file contents never logged; only filename + size.
+ */
+
+import { API_BASE } from './officeMemory';
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+export class BlueprintsApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    public readonly correlationId?: string,
+  ) {
+    super(message);
+    this.name = 'BlueprintsApiError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max raw file size (50 MB). Base64 inflates ~33% so the JSON body cap on
+ *  the server route is set higher — see server/routes.ts blueprints upload. */
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+/** MIME types accepted by the upload route. */
+export const ACCEPTED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+  'image/heif',
+] as const;
+
+export type AcceptedMimeType = (typeof ACCEPTED_MIME_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Stage progress — 5-stage pipeline (Wave 6A real: ingest, classify;
+// Wave 3/4/5: see, reason, procure)
+// ---------------------------------------------------------------------------
+
+export type StageKey = 'ingest' | 'classify' | 'see' | 'reason' | 'procure';
+export type StageStatus = 'pending' | 'running' | 'ok' | 'error' | 'stub';
+
+export interface StageProgress {
+  ingest: StageStatus;
+  classify: StageStatus;
+  see: StageStatus;
+  reason: StageStatus;
+  procure: StageStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types (Drew via /api/v1/blueprints/upload)
+// ---------------------------------------------------------------------------
+
+/** Drew INGEST result (Wave 2A real implementation). */
+export interface IngestResult {
+  status: 'ok' | 'error' | 'dedup';
+  stage: 'ingest';
+  project_id?: string;
+  sheet_count?: number;
+  sheet_ids?: string[];
+  provider_mix?: Record<string, number>;
+  reason?: string;
+}
+
+/** Drew CLASSIFY result (Wave 2A real implementation). */
+export interface ClassifyResult {
+  status: 'ok' | 'error';
+  stage: 'classify';
+  project_id?: string;
+  discipline_counts?: Record<string, number>;
+  revisions?: number;
+  needs_review_count?: number;
+  reason?: string;
+}
+
+/** Server-side composed response: INGEST + auto-chained CLASSIFY. */
+export interface UploadBlueprintResponse {
+  success: boolean;
+  project_id: string;
+  filename: string;
+  size_bytes: number;
+  correlation_id: string;
+  /** Real raw INGEST result from Drew (Wave 2A). */
+  ingest: IngestResult;
+  /** CLASSIFY auto-chained on the server. May be `null` if INGEST errored. */
+  classify: ClassifyResult | null;
+  /** Composed 5-stage indicator the UI can hand straight to UploadProgressInline.
+   *  Wave 6A: ingest + classify reflect real backend status; see/reason/procure
+   *  are always 'pending' (Wave 3/4/5 will light them up). */
+  stage_progress: StageProgress;
+}
+
+/** Wave 6.5 — getProject() response (declared early for type-stability). */
+export interface BlueprintProject {
+  project_id: string;
+  suite_id: string;
+  office_id: string;
+  filename: string;
+  uploaded_at: string;
+  sheet_count: number;
+  stage_progress: StageProgress;
+}
+
+/** Wave 6.5 — listSheets() response item. */
+export interface BlueprintSheet {
+  sheet_id: string;
+  sheet_number: string;
+  discipline: string | null;
+  /** Higher = newer; superseded sheets have `superseded_by_sheet_id` set. */
+  revision: number;
+  superseded_by_sheet_id?: string | null;
+  thumbnail_url?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+type FetchFn = (url: string, options?: RequestInit) => Promise<Response>;
+
+export interface UploadBlueprintParams {
+  /** Raw file bytes — already validated client-side for size + MIME type. */
+  fileBytes: Uint8Array;
+  filename: string;
+  mimeType: AcceptedMimeType;
+  officeId: string;
+  /** Optional client-generated idempotency key for retry safety. */
+  idempotencyKey?: string;
+  /** Optional abort signal. */
+  signal?: AbortSignal;
+}
+
+/** Base64-encode a Uint8Array without blowing the call stack on large files.
+ *  apply() with a 50MB array hits "Maximum call stack size exceeded" on V8;
+ *  chunk to ~64KB and concat. */
+function _uint8ToBase64(bytes: Uint8Array): string {
+  // Use Buffer on Node (server-side) for speed; on browser fall back to chunked btoa.
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let bin = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunk)),
+    );
+  }
+  // eslint-disable-next-line no-restricted-globals
+  return btoa(bin);
+}
+
+/** Upload a blueprint PDF/image. Server-side proxy:
+ *    1) Validates size + MIME.
+ *    2) Mints capability token (Law #5).
+ *    3) Calls Drew INGEST.
+ *    4) On INGEST ok → auto-chains Drew CLASSIFY.
+ *    5) Returns the composed response. */
+export async function uploadBlueprint(
+  authenticatedFetch: FetchFn,
+  params: UploadBlueprintParams,
+): Promise<UploadBlueprintResponse> {
+  if (params.fileBytes.byteLength > MAX_UPLOAD_BYTES) {
+    throw new BlueprintsApiError(
+      413,
+      'FILE_TOO_LARGE',
+      `File exceeds ${(MAX_UPLOAD_BYTES / 1024 / 1024).toFixed(0)} MB cap`,
+    );
+  }
+  if (!ACCEPTED_MIME_TYPES.includes(params.mimeType)) {
+    throw new BlueprintsApiError(
+      415,
+      'UNSUPPORTED_MEDIA_TYPE',
+      `MIME type ${params.mimeType} not supported`,
+    );
+  }
+
+  const body = {
+    filename: params.filename,
+    mime_type: params.mimeType,
+    pdf_b64: _uint8ToBase64(params.fileBytes),
+    idempotency_key: params.idempotencyKey,
+  };
+
+  const resp = await authenticatedFetch(`${API_BASE}/api/v1/blueprints/upload`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Office-Id': params.officeId,
+    },
+    body: JSON.stringify(body),
+    signal: params.signal,
+  });
+
+  if (!resp.ok) {
+    let code = 'BLUEPRINT_UPLOAD_FAILED';
+    let message = `Blueprint upload failed (${resp.status})`;
+    let correlationId: string | undefined;
+    try {
+      const parsed = await resp.json();
+      code = parsed?.detail?.error ?? parsed?.error ?? parsed?.code ?? code;
+      message = parsed?.detail?.message ?? parsed?.message ?? message;
+      correlationId = parsed?.correlation_id;
+    } catch {
+      // non-JSON error body
+    }
+    throw new BlueprintsApiError(resp.status, code, message, correlationId);
+  }
+
+  return (await resp.json()) as UploadBlueprintResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Wave 6.5 stubs — types declared, implementations throw
+// ---------------------------------------------------------------------------
+
+/** Wave 6.5 — fetch a single project's metadata + progress.
+ *  Throws until backend GET endpoint lands. */
+export async function getProject(
+  _authenticatedFetch: FetchFn,
+  _projectId: string,
+  _officeId: string,
+): Promise<BlueprintProject> {
+  throw new BlueprintsApiError(
+    501,
+    'NOT_IMPLEMENTED_WAVE_6_5',
+    'getProject() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id',
+  );
+}
+
+/** Wave 6.5 — list sheets for a project (with thumbnails + revision chain).
+ *  Throws until backend GET endpoint lands. */
+export async function listSheets(
+  _authenticatedFetch: FetchFn,
+  _projectId: string,
+  _officeId: string,
+): Promise<BlueprintSheet[]> {
+  throw new BlueprintsApiError(
+    501,
+    'NOT_IMPLEMENTED_WAVE_6_5',
+    'listSheets() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id/sheets',
+  );
+}
+
+/** Wave 6.5 — poll project pipeline stage progress.
+ *  Throws until backend GET endpoint lands. */
+export async function getProjectStatus(
+  _authenticatedFetch: FetchFn,
+  _projectId: string,
+  _officeId: string,
+): Promise<{ stage_progress: StageProgress }> {
+  throw new BlueprintsApiError(
+    501,
+    'NOT_IMPLEMENTED_WAVE_6_5',
+    'getProjectStatus() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id/status',
+  );
+}

--- a/lib/blueprintUploadStore.ts
+++ b/lib/blueprintUploadStore.ts
@@ -1,0 +1,78 @@
+/**
+ * Blueprint Upload Store — Wave 6A.
+ *
+ * Tiny module-level listener-based store (matches the uiStore pattern). The
+ * Plans & Photos tab publishes its current upload state here so the Tim
+ * Rail Context tab can render the pipeline status, discipline counts,
+ * and last-upload metadata without a prop-drilled provider.
+ *
+ * Law #6: state is wiped on suite_id change (via reset). Nothing persists
+ * to localStorage — this is ephemeral session state only.
+ *
+ * Law #7: store is a render bus only — no decisions, no side-effects.
+ */
+import { useEffect, useState } from 'react';
+import type { UploadBlueprintResponse, StageProgress } from '@/lib/api/blueprintsApi';
+import type { UploadPhase } from '@/hooks/useBlueprintUpload';
+
+export interface BlueprintUploadSnapshot {
+  phase: UploadPhase;
+  filename: string | null;
+  uploadedAt: number | null;
+  response: UploadBlueprintResponse | null;
+  stageProgress: StageProgress;
+  error: { code: string; message: string } | null;
+}
+
+const INITIAL_STAGE: StageProgress = {
+  ingest: 'pending',
+  classify: 'pending',
+  see: 'pending',
+  reason: 'pending',
+  procure: 'pending',
+};
+
+const INITIAL: BlueprintUploadSnapshot = {
+  phase: 'idle',
+  filename: null,
+  uploadedAt: null,
+  response: null,
+  stageProgress: INITIAL_STAGE,
+  error: null,
+};
+
+let state: BlueprintUploadSnapshot = INITIAL;
+const listeners = new Set<(snap: BlueprintUploadSnapshot) => void>();
+
+function emit(): void {
+  listeners.forEach((l) => l(state));
+}
+
+export function getBlueprintUpload(): BlueprintUploadSnapshot {
+  return state;
+}
+
+export function setBlueprintUpload(
+  patch: Partial<BlueprintUploadSnapshot>,
+): void {
+  state = { ...state, ...patch };
+  emit();
+}
+
+export function resetBlueprintUpload(): void {
+  state = INITIAL;
+  emit();
+}
+
+/** Subscribe + re-render hook for the Tim Rail Context payload. */
+export function useBlueprintUploadSnapshot(): BlueprintUploadSnapshot {
+  const [snap, setSnap] = useState<BlueprintUploadSnapshot>(state);
+  useEffect(() => {
+    const l = (next: BlueprintUploadSnapshot): void => setSnap(next);
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  }, []);
+  return snap;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express';
+import express, { Router, Request, Response } from 'express';
 import crypto from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { storage } from './storage';
@@ -9810,6 +9810,333 @@ router.get('/api/v1/materials/search', async (req: Request, res: Response) => {
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Wave 6A — Blueprint Story Engine: POST /api/v1/blueprints/upload
+// ---------------------------------------------------------------------------
+// GREEN tier — Drew INGEST + CLASSIFY are read-side (parse the PDF, write
+// blueprint_projects + blueprint_sheets keyed by suite_id with RLS). We mint
+// a capability token (Law #5) and forward to the Python orchestrator via
+// `POST /v1/agents/invoke` — Drew agent — with task=INGEST. On success the
+// proxy auto-chains task=CLASSIFY using the project_id from INGEST.
+//
+// Request body (JSON):
+//   { filename: string,
+//     mime_type: 'application/pdf'|'image/jpeg'|'image/png'|'image/heic'|'image/heif',
+//     pdf_b64: string (base64-encoded raw file bytes),
+//     idempotency_key?: string }
+//
+// Body size: client-side cap is 50 MB raw → base64 inflates ~33% → JSON body
+// can reach ~67 MB. We register a 75 MB JSON parser scoped to this single
+// route (global parser stays at 1 MB).
+//
+// Response: see UploadBlueprintResponse in lib/api/blueprintsApi.ts. Composes
+// the real INGEST + CLASSIFY results into a single stage_progress shape.
+// ---------------------------------------------------------------------------
+
+const BLUEPRINT_UPLOAD_JSON_LIMIT = '75mb';
+const BLUEPRINT_MAX_RAW_BYTES = 50 * 1024 * 1024;
+const BLUEPRINT_ACCEPTED_MIME = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+  'image/heif',
+]);
+
+router.post(
+  '/api/v1/blueprints/upload',
+  express.json({ limit: BLUEPRINT_UPLOAD_JSON_LIMIT }),
+  async (req: Request, res: Response) => {
+    const suiteId = requireAuth(req, res);
+    if (!suiteId) return;
+
+    const orchestratorUrl = resolveOrchestratorUrl();
+    if (!orchestratorUrl) {
+      res.status(503).json({
+        error: 'ORCHESTRATOR_UNAVAILABLE',
+        message: 'Backend service is not configured',
+      });
+      return;
+    }
+
+    const officeIdRaw = (req.headers['x-office-id'] as string) || '';
+    const officeId =
+      typeof officeIdRaw === 'string' && officeIdRaw.trim() ? officeIdRaw.trim() : suiteId;
+    const tenantId = suiteId;
+    const actorId = ((req as any).authenticatedUserId as string) || suiteId;
+    const correlationId =
+      (req.headers['x-correlation-id'] as string) || `corr_${crypto.randomUUID()}`;
+    const traceId = (req.headers['x-trace-id'] as string) || correlationId;
+
+    // Validate body shape (Law #3: fail-closed on malformed input).
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const filename = typeof body.filename === 'string' ? body.filename.trim() : '';
+    const mimeType = typeof body.mime_type === 'string' ? body.mime_type.toLowerCase() : '';
+    const pdfB64 = typeof body.pdf_b64 === 'string' ? body.pdf_b64 : '';
+
+    if (!filename || !mimeType || !pdfB64) {
+      res.status(400).json({
+        error: 'INVALID_INPUT',
+        message: 'filename, mime_type, and pdf_b64 are required',
+        correlation_id: correlationId,
+      });
+      return;
+    }
+    if (!BLUEPRINT_ACCEPTED_MIME.has(mimeType)) {
+      res.status(415).json({
+        error: 'UNSUPPORTED_MEDIA_TYPE',
+        message: `mime_type ${mimeType} not accepted`,
+        correlation_id: correlationId,
+      });
+      return;
+    }
+
+    // Decode to validate size + strip the base64 envelope (the orchestrator
+    // accepts raw base64; we re-encode after validation to a stable form).
+    let rawBytesLen: number;
+    try {
+      // Buffer.from is forgiving — ignores whitespace and pads if missing.
+      rawBytesLen = Buffer.from(pdfB64, 'base64').byteLength;
+    } catch {
+      res.status(400).json({
+        error: 'INVALID_BASE64',
+        message: 'pdf_b64 is not valid base64',
+        correlation_id: correlationId,
+      });
+      return;
+    }
+    if (rawBytesLen === 0) {
+      res.status(400).json({
+        error: 'EMPTY_FILE',
+        message: 'Decoded file is empty',
+        correlation_id: correlationId,
+      });
+      return;
+    }
+    if (rawBytesLen > BLUEPRINT_MAX_RAW_BYTES) {
+      res.status(413).json({
+        error: 'FILE_TOO_LARGE',
+        message: `File is ${(rawBytesLen / 1024 / 1024).toFixed(1)} MB — max is ${(
+          BLUEPRINT_MAX_RAW_BYTES / 1024 / 1024
+        ).toFixed(0)} MB`,
+        correlation_id: correlationId,
+      });
+      return;
+    }
+
+    // Mint capability token (Law #5) — scope=blueprints:upload.
+    if (!resolveSigningKey()) {
+      res.status(503).json({
+        error: 'SIGNING_KEY_UNAVAILABLE',
+        message: 'Capability token signing key not configured',
+      });
+      return;
+    }
+    const minted = mintCapabilityToken({
+      scope: 'blueprints:upload',
+      tenant_id: tenantId,
+      suite_id: suiteId,
+      office_id: officeId,
+      correlation_id: correlationId,
+    });
+    if (!minted) {
+      res.status(503).json({
+        error: 'SIGNING_KEY_UNAVAILABLE',
+        message: 'Capability token signing key not configured',
+      });
+      return;
+    }
+
+    // ── Stage 1: Drew INGEST ──
+    const ingestBody = {
+      agent: 'drew',
+      task: 'INGEST',
+      suite_id: suiteId,
+      office_id: officeId,
+      correlation_id: correlationId,
+      capability_token: minted.token,
+      payload: {
+        pdf_bytes: pdfB64,
+        filename,
+        suite_id: suiteId,
+        office_id: officeId,
+      },
+    };
+
+    // Structured log — never log pdf bytes or token.
+    logger.info('[BlueprintsUpload] INGEST start', {
+      suite_id: suiteId,
+      office_id: officeId,
+      trace_id: traceId,
+      correlation_id: correlationId,
+      size_bytes: rawBytesLen,
+    });
+
+    const ingestController = new AbortController();
+    const ingestTimer = setTimeout(() => ingestController.abort(), 120_000);
+    let ingestResult: any = null;
+    let ingestStatus = 0;
+    try {
+      const orchResp = await fetch(`${orchestratorUrl}/v1/agents/invoke`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tenant-Id': tenantId,
+          'X-Suite-Id': suiteId,
+          'X-Office-Id': officeId,
+          'X-Actor-Id': actorId,
+          'X-Correlation-Id': correlationId,
+          'X-Trace-Id': traceId,
+        },
+        body: JSON.stringify(ingestBody),
+        signal: ingestController.signal,
+      });
+      clearTimeout(ingestTimer);
+      ingestStatus = orchResp.status;
+      const text = await orchResp.text();
+      try {
+        ingestResult = text ? JSON.parse(text) : null;
+      } catch {
+        ingestResult = { status: 'error', stage: 'ingest', reason: 'upstream_non_json' };
+      }
+      if (!orchResp.ok) {
+        logger.warn('[BlueprintsUpload] INGEST upstream non-2xx', {
+          suite_id: suiteId,
+          status: orchResp.status,
+        });
+        res.status(orchResp.status).json({
+          error: 'INGEST_UPSTREAM_ERROR',
+          message:
+            (ingestResult && (ingestResult.message || ingestResult.error)) ||
+            `Backend returned ${orchResp.status}`,
+          correlation_id: correlationId,
+        });
+        return;
+      }
+    } catch (err: unknown) {
+      clearTimeout(ingestTimer);
+      const isTimeout = err instanceof Error && err.name === 'AbortError';
+      logger.error('[BlueprintsUpload] INGEST fetch failed', {
+        suite_id: suiteId,
+        reason: err instanceof Error ? err.name + ': ' + err.message.slice(0, 120) : 'unknown',
+        is_timeout: isTimeout,
+      });
+      res.status(isTimeout ? 504 : 502).json({
+        error: isTimeout ? 'ORCHESTRATOR_TIMEOUT' : 'ORCHESTRATOR_UNREACHABLE',
+        message: isTimeout ? 'Backend did not respond in time' : 'Could not reach backend service',
+        correlation_id: correlationId,
+      });
+      return;
+    }
+
+    // Compose stage_progress as we go.
+    const stageProgress: Record<string, string> = {
+      ingest: ingestResult?.status === 'error' ? 'error' : 'ok',
+      classify: 'pending',
+      see: 'pending',
+      reason: 'pending',
+      procure: 'pending',
+    };
+
+    // In-band INGEST failure (HTTP 200, status: 'error') — return early.
+    if (ingestResult?.status === 'error' || !ingestResult?.project_id) {
+      logger.warn('[BlueprintsUpload] INGEST in-band error', {
+        suite_id: suiteId,
+        reason: ingestResult?.reason,
+      });
+      res.status(200).json({
+        success: false,
+        project_id: ingestResult?.project_id ?? '',
+        filename,
+        size_bytes: rawBytesLen,
+        correlation_id: correlationId,
+        ingest: ingestResult ?? { status: 'error', stage: 'ingest', reason: 'unknown' },
+        classify: null,
+        stage_progress: stageProgress,
+      });
+      return;
+    }
+
+    const projectId: string = String(ingestResult.project_id);
+
+    // ── Stage 2: Drew CLASSIFY (auto-chained) ──
+    const classifyBody = {
+      agent: 'drew',
+      task: 'CLASSIFY',
+      suite_id: suiteId,
+      office_id: officeId,
+      correlation_id: correlationId,
+      capability_token: minted.token,
+      payload: {
+        project_id: projectId,
+        suite_id: suiteId,
+      },
+    };
+
+    const classifyController = new AbortController();
+    const classifyTimer = setTimeout(() => classifyController.abort(), 60_000);
+    let classifyResult: any = null;
+    try {
+      const orchResp = await fetch(`${orchestratorUrl}/v1/agents/invoke`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Tenant-Id': tenantId,
+          'X-Suite-Id': suiteId,
+          'X-Office-Id': officeId,
+          'X-Actor-Id': actorId,
+          'X-Correlation-Id': correlationId,
+          'X-Trace-Id': traceId,
+        },
+        body: JSON.stringify(classifyBody),
+        signal: classifyController.signal,
+      });
+      clearTimeout(classifyTimer);
+      const text = await orchResp.text();
+      try {
+        classifyResult = text ? JSON.parse(text) : null;
+      } catch {
+        classifyResult = { status: 'error', stage: 'classify', reason: 'upstream_non_json' };
+      }
+      stageProgress.classify =
+        orchResp.ok && classifyResult?.status === 'ok' ? 'ok' : 'error';
+    } catch (err: unknown) {
+      clearTimeout(classifyTimer);
+      logger.warn('[BlueprintsUpload] CLASSIFY fetch failed (non-fatal)', {
+        suite_id: suiteId,
+        reason: err instanceof Error ? err.name : 'unknown',
+      });
+      classifyResult = {
+        status: 'error',
+        stage: 'classify',
+        reason: 'fetch_failed',
+      };
+      stageProgress.classify = 'error';
+    }
+
+    logger.info('[BlueprintsUpload] complete', {
+      suite_id: suiteId,
+      office_id: officeId,
+      trace_id: traceId,
+      correlation_id: correlationId,
+      project_id: projectId,
+      sheet_count: ingestResult?.sheet_count,
+      classify_status: classifyResult?.status,
+    });
+
+    res.status(200).json({
+      success: true,
+      project_id: projectId,
+      filename,
+      size_bytes: rawBytesLen,
+      correlation_id: correlationId,
+      ingest: ingestResult,
+      classify: classifyResult,
+      stage_progress: stageProgress,
+    });
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Pass D: /api/v1/materials/bundles/* — bundle CRUD + push-to-estimate


### PR DESCRIPTION
## Objective
Turn the Plans & Photos tab from a `TabPlaceholder` stub into the production upload + sheet-organization workstation for Drew's Blueprint Story Engine. Reduced-scope per founder decision (Option A) — backend GET endpoints don't exist yet, so this PR ships the upload path end-to-end and defers thumbnails + polling to Wave 6.5.

## Facts (verified before building)
- `dev/blueprint-engine` HEAD `35584b4` (Wave 0 only — Wave 1/2 were backend-only).
- Backend Drew agent (Wave 2A + 2B) at `POST /v1/agents/invoke` with `task: INGEST | CLASSIFY` is live. INGEST returns `{ project_id, sheet_count, sheet_ids }`; CLASSIFY returns `{ discipline_counts, revisions, needs_review_count }`.
- Backend has NO GET endpoints for projects/sheets/status — confirmed via `grep -rn "/v1/blueprints" backend/orchestrator/src` returning zero matches. These ship in Wave 2.5 (separate backend PR per founder).

## Decision — Option A: reduced scope
- Ship upload + INGEST + auto-chained CLASSIFY synchronously through one server proxy.
- Defer thumbnails, 5-stage polling, and revision-chain UX to Wave 6.5 once backend reads land.
- Build shared shell components (`CanvasCardSwitcher`, `BottomChipStrip`, `ContextTabPayload`) now so Wave 7/8 + the Wave 6B polish pass inherit a clean baseline.

## Changes
**Server proxy:**
- `server/routes.ts:9814-10100` — `POST /api/v1/blueprints/upload`. 75 MB route-scoped JSON parser, MIME + size validation, base64 validation, capability token mint (scope `blueprints:upload`), Drew INGEST call, auto-chained CLASSIFY, composed 5-stage `stage_progress` in response.
- Added `import express, …` to support route-scoped body parser.

**API client + hooks:**
- `lib/api/blueprintsApi.ts` — `uploadBlueprint()` real; `getProject`/`listSheets`/`getProjectStatus` typed but throw `NOT_IMPLEMENTED_WAVE_6_5`. Constants: `MAX_UPLOAD_BYTES`, `ACCEPTED_MIME_TYPES`. Types: `StageProgress`, `IngestResult`, `ClassifyResult`, `UploadBlueprintResponse`, `BlueprintProject`, `BlueprintSheet`.
- `hooks/useBlueprintUpload.ts` — upload state machine (idle → reading → uploading → ingesting → classifying → success | error). Publishes to module-level store so the Tim Rail Context payload observes without a provider.
- `hooks/useBlueprintProject.ts` — Wave 6.5 stub with the final shape, returns empty state today.
- `lib/blueprintUploadStore.ts` — listener-based module store matching the `uiStore.ts` pattern.

**Shared shell components (`components/service-hub/estimate-studio/shell/`):**
- `CanvasCardSwitcher.tsx` — hosts ONE canvas card at a time with 200ms cross-fade (CLS=0).
- `BottomChipStrip.tsx` — horizontal-scroll selector chips with active/hover/disabled states.
- `ContextTabPayload.tsx` — generic Tim Rail Context payload host (titled sections).

**Plans & Photos tab (`components/service-hub/estimate-studio/plans-photos/`):**
- `PlansPhotosTab.tsx` — owns the empty → populated states, auto-jumps to Sheets on first upload, renders the wave-coming-soon banner. 4 chip views: Upload / All Sheets / By Discipline / Revisions.
- `UploadDropZone.tsx` — production drop zone. Drag-drop, clipboard paste, native file picker, 50 MB cap, real progress, premium error states.
- `UploadProgressInline.tsx` — 5-stage pipeline indicator (horizontal canvas + vertical rail layouts). INGEST + CLASSIFY carry real status; SEE/REASON/PROCURE are dimmed Wave 3/4/5 placeholders.
- `SheetRoster.tsx` — Wave 6A roster (no thumbnails). Discipline summary chips + per-sheet list driven by INGEST `sheet_ids` + CLASSIFY `discipline_counts`.
- `RevisionBadge.tsx` — small `REV n` / `SUPERSEDED` pill. Tooltip-chain UI deferred to Wave 6.5.
- `disciplines.ts` — AIA discipline color map (A/S/M/E/P/FP/C/L/SP/SC/AD).

**Tim Rail Context payload:**
- `components/service-hub/estimate-studio/tim-rail/PlansPhotosContextPayload.tsx` — 4 sections: pipeline status (vertical), discipline counts (compact chips), last upload (relative time), revision activity.
- `TimRailContextTab.tsx` — wired the new payload behind a `pathname.endsWith('/plans-photos')` guard. Property facts unchanged + carry over.

**Route + regression-lock:**
- `app/service-hub/estimate-studio/plans-photos.tsx` — replaced `TabPlaceholder` with `<PlansPhotosTab />`.
- `__tests__/visuals/regression-lock.test.ts` — added Lock #16 (5 assertions): canvas card switcher used, chip strip used, drop zone used, route delegates correctly, wave-coming-soon banner literal present.

## Verification
- `npx tsc --noEmit` — zero new errors in Wave 6A code. Total error count is 162, identical to `dev/blueprint-engine` baseline (stash + compare confirmed).
- `npx jest __tests__/visuals/regression-lock.test.ts -t "Lock #1[3-6]"` — **16/16 passing** (Locks #13, #14, #15, #16). Lock #2 failure (Street View zoom: 3 vs 2) exists on baseline too — pre-existing, unrelated.
- `npx jest --testPathPattern="(plans-photos|blueprint|materials)"` — same 2 failures as baseline (`ProductCard.test.tsx` flake + adjacent suites). Zero regression introduced.
- File-presence sweep: all 15 new + 4 modified files exist at expected paths.
- Server route smoke check: `routes.ts:9826-10100` compiles clean.

**Localhost smoke test (manual, recommended before merge):**
1. `npm run dev:web` (Aspire-Desktop)
2. Boot backend orchestrator locally (or point `ORCHESTRATOR_URL` at staging).
3. Navigate to `/service-hub/estimate-studio/plans-photos`.
4. Confirm: empty drop hero + Wave 6.5 banner visible.
5. Drop a PDF (≤ 50 MB) → progress runs → success card with discipline chips + sheet roster.
6. Open Tim Rail Context tab → see pipeline status + discipline counts.

Screenshots can't be produced from this sandboxed agent (no browser); founder will validate visually on localhost.

## Risks & Next Steps
**Risks:**
- 50 MB upload base64-encoded inflates to ~67 MB JSON body. Route-scoped `express.json({ limit: '75mb' })` covers this without affecting the global 1 MB parser, but very large PDFs at the edge of the cap will spike memory briefly during base64 decode in the proxy.
- The proxy is synchronous: a 50 MB PDF + Drew INGEST (LlamaParse) + CLASSIFY can take 60-120s. Client-side timeout is governed by the user's network stack — there's no client `setTimeout` so it will wait. UX shows the progress strip the whole time. If Drew exceeds the proxy's 120s INGEST timeout, client surfaces `ORCHESTRATOR_TIMEOUT`.
- TimRailContextTab reads from a module-level store. Multi-window scenarios (rare on desktop) would share state — acceptable for Wave 6A; Wave 6.5 polling will key off `project_id` per route.

**Wave 6B polish (separate PR after this merges):**
- Framer-quality typography pass on Plans & Photos canvas (no layout changes — refine spacing, motion, micro-states).
- Hover/focus states on the chip strip.
- Discipline chip glyph upgrade (replace single-letter codes with custom marks).

**Wave 6.5 (after Wave 2.5 backend + Wave 3 SEE):**
- Real `SheetThumbnailGrid` + `SheetThumbnailCard` (needs Wave 2.5 thumbnail URLs).
- Polling `useBlueprintProject` (needs `GET /v1/blueprints/projects/:id/status`).
- Per-sheet revision chain tooltip (needs `GET /v1/blueprints/projects/:id/sheets`).
- Light up SEE/REASON/PROCURE pills once Wave 3+ ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)