### PR TITLE
feat(scope): Wave 7 — Scope tab with story / missing inputs / tariff

### DIFF
--- a/__tests__/scope/scope-tab.test.tsx
+++ b/__tests__/scope/scope-tab.test.tsx
@@ -1,0 +1,413 @@
+/**
+ * Scope Tab — Wave 7 unit tests.
+ *
+ * Covers observable UX behavior:
+ *   - Empty state renders the CTA back to Plans & Photos
+ *   - Default chip selection is Story
+ *   - Switching chips swaps the active canvas card
+ *   - MissingInputCard Confirm flow calls resolveMissingInput and shows the
+ *     resolved state on success
+ *   - TruthBadge variants render correctly per truth class
+ */
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import type {
+  BlueprintAssembly,
+  BlueprintMaterial,
+  BlueprintMissingInput,
+  BlueprintStory,
+} from '@/lib/api/blueprintsApi';
+
+// ---------------------------------------------------------------------------
+// Mocks — TenantProvider, authenticatedFetch, router, blueprint API, upload
+// store. We mount ScopeTab with handcrafted state per test.
+// ---------------------------------------------------------------------------
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), back: jest.fn() }),
+  usePathname: () => '/service-hub/estimate-studio/scope',
+}));
+
+jest.mock('@/providers', () => ({
+  useTenant: () => ({ officeId: 'office-test-001' }),
+}));
+
+jest.mock('@/lib/authenticatedFetch', () => ({
+  useAuthFetch: () => ({
+    authenticatedFetch: jest.fn(),
+  }),
+}));
+
+const mockResolveMissingInput = jest.fn();
+jest.mock('@/lib/api/blueprintsApi', () => {
+  const actual = jest.requireActual('@/lib/api/blueprintsApi');
+  return {
+    ...actual,
+    getStory: jest.fn(),
+    getAssemblies: jest.fn(),
+    getMaterials: jest.fn(),
+    getMissingInputs: jest.fn(),
+    resolveMissingInput: (...args: unknown[]) => mockResolveMissingInput(...args),
+  };
+});
+
+// Mock the upload store to return a project_id.
+const mockUploadSnap = {
+  phase: 'success' as const,
+  filename: 'plan-set.pdf',
+  uploadedAt: Date.now(),
+  response: {
+    success: true,
+    project_id: 'proj-test-001',
+    filename: 'plan-set.pdf',
+    size_bytes: 1024,
+    correlation_id: 'corr-1',
+    ingest: { status: 'ok', stage: 'ingest', project_id: 'proj-test-001' },
+    classify: null,
+    stage_progress: {
+      ingest: 'ok',
+      classify: 'pending',
+      see: 'pending',
+      reason: 'pending',
+      procure: 'pending',
+    },
+  } as any,
+  stageProgress: {
+    ingest: 'ok',
+    classify: 'pending',
+    see: 'pending',
+    reason: 'pending',
+    procure: 'pending',
+  } as any,
+  error: null,
+};
+
+const mockEmptyUploadSnap = {
+  phase: 'idle' as const,
+  filename: null,
+  uploadedAt: null,
+  response: null,
+  stageProgress: {
+    ingest: 'pending',
+    classify: 'pending',
+    see: 'pending',
+    reason: 'pending',
+    procure: 'pending',
+  } as any,
+  error: null,
+};
+
+let mockUploadSnapState = mockEmptyUploadSnap as
+  | typeof mockEmptyUploadSnap
+  | typeof mockUploadSnap;
+jest.mock('@/lib/blueprintUploadStore', () => ({
+  useBlueprintUploadSnapshot: () => mockUploadSnapState,
+  getBlueprintUpload: () => mockUploadSnapState,
+  setBlueprintUpload: jest.fn(),
+  resetBlueprintUpload: jest.fn(),
+}));
+
+// Mock useBlueprintStory so we can stage scenarios.
+const baseStory: BlueprintStory = {
+  project_id: 'proj-test-001',
+  mean_confidence: 0.82,
+  truth_distribution: {
+    observed: 12,
+    derived: 5,
+    assumed: 2,
+    missing: 1,
+    field_confirmed: 0,
+    vendor_confirmed: 0,
+    permit_confirmed: 0,
+  },
+  phases: [
+    {
+      key: 'phase_1',
+      title: 'Demo & MEP rough-in',
+      body_md: 'Demo existing partitions and run MEP rough.',
+      facts: [
+        {
+          key: 'fact_1',
+          label: 'Existing 9 ft ceiling',
+          truth: 'observed',
+          confidence: 1,
+        },
+        {
+          key: 'fact_2',
+          label: 'Likely 24" o.c. studs',
+          truth: 'assumed',
+          confidence: 0.62,
+          missing_input_id: 'mi_1',
+        },
+      ],
+    },
+  ],
+  updated_at: new Date().toISOString(),
+  status: 'done',
+};
+
+const baseAssemblies: BlueprintAssembly[] = [
+  {
+    assembly_id: 'asm_1',
+    assembly_type: 'drywall_partition',
+    label: 'Drywall partition — Type X 5/8"',
+    quantity: 320,
+    unit: 'sf',
+    truth: 'observed',
+    in_base_scope: true,
+  },
+  {
+    assembly_id: 'asm_2',
+    assembly_type: 'demountable_partition',
+    label: 'Demountable partition alt',
+    quantity: 320,
+    unit: 'sf',
+    truth: 'derived',
+    confidence: 0.74,
+    in_base_scope: false,
+    alternate_note: 'Bid as drywall OR demountable — 23% cost delta.',
+  },
+];
+
+const baseMaterials: BlueprintMaterial[] = [
+  {
+    material_id: 'mat_1',
+    label: 'Type X drywall 5/8" — 4\'x8\' sheet',
+    quantity: 50,
+    unit: 'sheet',
+    truth: 'observed',
+    tariff_flagged: false,
+  },
+  {
+    material_id: 'mat_2',
+    label: 'Steel stud 3-5/8" x 10ft',
+    quantity: 120,
+    unit: 'ea',
+    truth: 'observed',
+    tariff_flagged: true,
+    tariff_note: 'Section 232 steel',
+    tariff_impact_usd: 145,
+  },
+];
+
+const baseMissing: BlueprintMissingInput[] = [
+  {
+    input_id: 'mi_1',
+    description: 'Ceiling height not specified on sheet A-2',
+    suggested_resolution: 'Confirm with owner — typical 9 ft for commercial-lite.',
+    status: 'open',
+  },
+];
+
+let mockStoryState: ReturnType<typeof makeStoryState> = makeStoryState({});
+
+function makeStoryState(overrides: {
+  story?: BlueprintStory | null;
+  assemblies?: BlueprintAssembly[];
+  materials?: BlueprintMaterial[];
+  missingInputs?: BlueprintMissingInput[];
+  backendDeployed?: boolean;
+}): {
+  story: BlueprintStory | null;
+  assemblies: BlueprintAssembly[];
+  materials: BlueprintMaterial[];
+  missingInputs: BlueprintMissingInput[];
+  isLoading: boolean;
+  isPolling: boolean;
+  backendDeployed: boolean;
+  error: null;
+  refetch: () => Promise<void>;
+} {
+  return {
+    story: overrides.story === undefined ? baseStory : overrides.story,
+    assemblies: overrides.assemblies ?? baseAssemblies,
+    materials: overrides.materials ?? baseMaterials,
+    missingInputs: overrides.missingInputs ?? baseMissing,
+    isLoading: false,
+    isPolling: false,
+    backendDeployed: overrides.backendDeployed ?? true,
+    error: null,
+    refetch: jest.fn(async () => {}),
+  };
+}
+
+jest.mock('@/hooks/useBlueprintStory', () => ({
+  useBlueprintStory: () => mockStoryState,
+}));
+
+// useBlueprintActions: uses React state internally so a confirm flips the
+// per-input phase + triggers a re-render exactly like the real hook would.
+jest.mock('@/hooks/useBlueprintActions', () => {
+  const React = jest.requireActual('react');
+  return {
+    useBlueprintActions: () => {
+      const [phases, setPhases] = React.useState<Record<string, string>>({});
+      return {
+        phaseFor: (key: string) => phases[key] ?? 'idle',
+        errorFor: () => null,
+        confirmMissingInput: async (
+          projectId: string,
+          inputId: string,
+          value: string,
+        ) => {
+          mockResolveMissingInput(projectId, inputId, value);
+          setPhases((prev: Record<string, string>) => ({
+            ...prev,
+            [inputId]: 'success',
+          }));
+          return {
+            input_id: inputId,
+            description: 'mock',
+            status: 'resolved',
+            resolved_value: value,
+            resolved_at: new Date().toISOString(),
+          };
+        },
+        markAlternate: async () => {},
+        requestRFI: async () => {},
+      };
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports under test — done AFTER jest.mock declarations.
+// ---------------------------------------------------------------------------
+
+import { ScopeTab } from '@/components/service-hub/estimate-studio/scope/ScopeTab';
+import { TruthBadge } from '@/components/service-hub/estimate-studio/scope/TruthBadge';
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockResolveMissingInput.mockClear();
+});
+
+describe('Scope Tab — Wave 7 shell', () => {
+  it('empty state renders the CTA back to Plans & Photos', () => {
+    mockUploadSnapState = mockEmptyUploadSnap;
+    mockStoryState = makeStoryState({});
+    const { getByTestId, getByText } = render(<ScopeTab />);
+
+    expect(getByTestId('scope-tab-empty')).toBeTruthy();
+    expect(
+      getByText(/Drop a plan set in Plans & Photos/),
+    ).toBeTruthy();
+
+    fireEvent.press(getByTestId('scope-tab-empty-cta'));
+    expect(mockPush).toHaveBeenCalledWith(
+      '/service-hub/estimate-studio/plans-photos',
+    );
+  });
+
+  it('default chip selection is Story (and StoryPanel is rendered)', () => {
+    mockUploadSnapState = mockUploadSnap;
+    mockStoryState = makeStoryState({});
+    const { getByTestId } = render(<ScopeTab />);
+
+    expect(getByTestId('scope-tab')).toBeTruthy();
+    // Story chip should be selected; StoryPanel is the visible canvas card.
+    expect(getByTestId('story-panel')).toBeTruthy();
+    const storyChip = getByTestId('bottom-chip-story');
+    expect(storyChip.props.accessibilityState?.selected).toBe(true);
+  });
+
+  it('switching chips swaps the active canvas card', async () => {
+    mockUploadSnapState = mockUploadSnap;
+    mockStoryState = makeStoryState({});
+    const { getByTestId, queryByTestId } = render(<ScopeTab />);
+
+    // Click "Included Work" chip → IncludedWorkCard appears once the
+    // CanvasCardSwitcher cross-fade (200ms) completes.
+    fireEvent.press(getByTestId('bottom-chip-included'));
+    await waitFor(() => expect(getByTestId('included-work-card')).toBeTruthy());
+
+    // Click "Tariff Exposure" chip → TariffExposureCard appears.
+    fireEvent.press(getByTestId('bottom-chip-tariff'));
+    await waitFor(() => expect(getByTestId('tariff-exposure-card')).toBeTruthy());
+
+    // Story panel should no longer be the visible card (CanvasCardSwitcher
+    // mounts only the active card).
+    expect(queryByTestId('story-panel')).toBeNull();
+  });
+
+  it('MissingInputCard Confirm flow calls resolveMissingInput and shows resolved state', async () => {
+    mockUploadSnapState = mockUploadSnap;
+    mockStoryState = makeStoryState({});
+    const { getByTestId } = render(<ScopeTab />);
+
+    // Switch to Missing Inputs chip (await the 200ms cross-fade).
+    fireEvent.press(getByTestId('bottom-chip-missing'));
+    await waitFor(() => expect(getByTestId('missing-inputs-list')).toBeTruthy());
+
+    // Open the confirm form.
+    fireEvent.press(getByTestId('missing-input-mi_1-open-confirm'));
+    const textInput = await waitFor(() => getByTestId('missing-input-mi_1-text'));
+    fireEvent.changeText(textInput, '9 ft 0 in');
+    await act(async () => {
+      fireEvent.press(getByTestId('missing-input-mi_1-submit'));
+    });
+
+    expect(mockResolveMissingInput).toHaveBeenCalledWith(
+      'proj-test-001',
+      'mi_1',
+      '9 ft 0 in',
+    );
+
+    // The action mock set the per-input phase to 'success'. On next render
+    // (which `act()` flushes), MissingInputCard's `isResolved` branch
+    // takes over and the row swaps to the *-resolved testID. We assert via
+    // `findByTestId` so the implicit waitFor walks the next paint.
+    await waitFor(
+      () => expect(getByTestId('missing-input-mi_1-resolved')).toBeTruthy(),
+      { timeout: 2000 },
+    );
+  });
+
+  it('shows the Wave 2.7 banner when backend GETs return 404', () => {
+    mockUploadSnapState = mockUploadSnap;
+    mockStoryState = makeStoryState({
+      backendDeployed: false,
+      story: null,
+      assemblies: [],
+      materials: [],
+      missingInputs: [],
+    });
+    const { getByTestId } = render(<ScopeTab />);
+
+    expect(getByTestId('scope-tab-wave-banner')).toBeTruthy();
+  });
+});
+
+describe('TruthBadge — Wave 7 variant rendering', () => {
+  it.each([
+    ['observed', 'observed'],
+    ['derived', 'derived'],
+    ['assumed', 'assumed'],
+    ['missing', 'missing'],
+    ['field_confirmed', 'field confirmed'],
+    ['vendor_confirmed', 'vendor confirmed'],
+    ['permit_confirmed', 'permit confirmed'],
+  ] as const)('renders the %s label', (truth, expectedLabel) => {
+    const { getByText, getByTestId } = render(
+      <TruthBadge truth={truth} />,
+    );
+    expect(getByTestId(`truth-badge-${truth}`)).toBeTruthy();
+    expect(getByText(expectedLabel)).toBeTruthy();
+  });
+
+  it('appends confidence to derived / assumed variants', () => {
+    const { getByText } = render(
+      <TruthBadge truth="derived" confidence={0.91} />,
+    );
+    expect(getByText(/0\.91/)).toBeTruthy();
+  });
+
+  it('does NOT append confidence to observed', () => {
+    const { queryByText } = render(
+      <TruthBadge truth="observed" confidence={0.91} />,
+    );
+    expect(queryByText(/0\.91/)).toBeNull();
+  });
+});

--- a/__tests__/visuals/regression-lock.test.ts
+++ b/__tests__/visuals/regression-lock.test.ts
@@ -284,6 +284,48 @@ describe('Visuals Tab — Design Lock v1.0', () => {
     });
   });
 
+  describe('Lock #17: Scope tab uses shared shell + renders inline TruthBadges', () => {
+    // Wave 7 (2026-05-17): Scope is THE tab where contractors read the plain-
+    // English story. It MUST use the same CanvasCardSwitcher + BottomChipStrip
+    // shells (so card geometry stays consistent across tabs) and MUST render
+    // inline TruthBadge components in the story so contractors can instantly
+    // tell observed-vs-derived-vs-assumed facts.
+    const tabSrc = read(
+      'components/service-hub/estimate-studio/scope/ScopeTab.tsx',
+    );
+    const storySrc = read(
+      'components/service-hub/estimate-studio/scope/StoryPanel.tsx',
+    );
+    const pageSrc = read('app/service-hub/estimate-studio/scope.tsx');
+
+    it('uses <CanvasCardSwitcher /> for the main canvas region', () => {
+      expect(tabSrc).toMatch(/CanvasCardSwitcher/);
+      expect(tabSrc).toMatch(/<CanvasCardSwitcher\b/);
+    });
+
+    it('uses <BottomChipStrip /> for card selection', () => {
+      expect(tabSrc).toMatch(/BottomChipStrip/);
+      expect(tabSrc).toMatch(/<BottomChipStrip\b/);
+    });
+
+    it('StoryPanel renders inline <TruthBadge /> components', () => {
+      expect(storySrc).toMatch(/TruthBadge/);
+      expect(storySrc).toMatch(/<TruthBadge\b/);
+    });
+
+    it('empty state copy contains the literal "Drop a plan set in Plans & Photos"', () => {
+      // Tonio: this is the contractor's entry breadcrumb when no project has
+      // been uploaded. The literal must remain so the visible UX matches the
+      // contract.
+      expect(tabSrc).toMatch(/Drop a plan set in Plans & Photos/);
+    });
+
+    it('scope.tsx route delegates to <ScopeTab /> (no TabPlaceholder)', () => {
+      expect(pageSrc).toMatch(/<ScopeTab\s*\/>/);
+      expect(pageSrc).not.toMatch(/TabPlaceholder/);
+    });
+  });
+
   describe('Lock #16: Plans & Photos tab uses shared shell (CanvasCardSwitcher + BottomChipStrip)', () => {
     // Wave 6A (2026-05-17): Plans & Photos is the primary upload entry for
     // the Blueprint Story Engine. It must use the shared canvas-card switcher

--- a/app/service-hub/estimate-studio/scope.tsx
+++ b/app/service-hub/estimate-studio/scope.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { TabPlaceholder } from '@/components/service-hub/estimate-studio/TabPlaceholder';
+import { ScopeTab } from '@/components/service-hub/estimate-studio/scope/ScopeTab';
 
-export default function ScopeTab() {
-  return (
-    <TabPlaceholder
-      tabName="Scope"
-      phaseN={7}
-      icon="list-outline"
-      description="Package decision board — Included Work, Not in Base Scope, Missing Inputs, Alternates. Delivery model alignment. Phase 7."
-    />
-  );
+/**
+ * Scope tab route (Wave 7).
+ *
+ * Delegates to <ScopeTab /> — the canvas-card shell that hosts Story,
+ * Included Work, Not in Base, Missing Inputs, Alternates, and Tariff
+ * Exposure cards.
+ */
+export default function ScopeRoute(): React.ReactElement {
+  return <ScopeTab />;
 }

--- a/components/service-hub/estimate-studio/scope/AlternatesCard.tsx
+++ b/components/service-hub/estimate-studio/scope/AlternatesCard.tsx
@@ -1,0 +1,228 @@
+/**
+ * AlternatesCard — Wave 7.
+ *
+ * Lists derived-but-low-confidence assemblies the LLM offered as
+ * alternates (e.g. "Bid as drywall OR demountable partition — 23% cost
+ * delta"). Tapping "Include" / "Exclude" should move the assembly into or
+ * out of the base scope.
+ *
+ * Wave 7 reality: the backend mutation for `markAlternate` lands in a
+ * follow-up wave. The buttons are wired but surface a NOT_IMPLEMENTED
+ * error inline so the UX clearly tells the contractor what's coming.
+ */
+import React from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintAssembly } from '@/lib/api/blueprintsApi';
+import { AssemblyRow } from './AssemblyRow';
+import type { UseBlueprintActionsResult } from '@/hooks/useBlueprintActions';
+
+interface Props {
+  assemblies: BlueprintAssembly[];
+  actions: UseBlueprintActionsResult;
+}
+
+export function AlternatesCard({ assemblies, actions }: Props): React.ReactElement {
+  // An "alternate" is any assembly with a non-null alternate_note. Drew
+  // sets this when REASON flagged the item as an owner-choice swap.
+  const alternates = assemblies.filter((a) => a.alternate_note != null);
+
+  if (alternates.length === 0) {
+    return (
+      <View style={styles.empty} testID="alternates-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="swap-horizontal-outline"
+            size={28}
+            color="rgba(255,255,255,0.55)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>No alternates yet</Text>
+        <Text style={styles.emptyBody}>
+          REASON didn't surface any owner-choice swaps for this plan set.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="alternates-card"
+    >
+      <View style={styles.header}>
+        <Text style={styles.headline}>Alternates</Text>
+        <Text style={styles.subhead}>
+          {alternates.length} owner-choice swap{alternates.length === 1 ? '' : 's'} —
+          mark each as included in base scope or excluded.
+        </Text>
+      </View>
+      <View style={styles.list}>
+        {alternates.map((assembly) => {
+          const phase = actions.phaseFor(assembly.assembly_id);
+          const err = actions.errorFor(assembly.assembly_id);
+          return (
+            <View key={assembly.assembly_id} style={styles.alternateGroup}>
+              <AssemblyRow
+                assembly={assembly}
+                testIDPrefix="alternate-row"
+                trailing={
+                  <View style={styles.trailingActions}>
+                    <Pressable
+                      onPress={() =>
+                        actions.markAlternate(assembly.assembly_id, { choice: 'include' })
+                      }
+                      disabled={phase === 'submitting'}
+                      accessibilityRole="button"
+                      accessibilityLabel="Include in base scope"
+                      style={({ hovered, pressed }: any) => [
+                        styles.actionBtn,
+                        styles.actionBtnPrimary,
+                        hovered && styles.actionBtnHover,
+                        pressed && styles.actionBtnPressed,
+                      ]}
+                      testID={`alternate-include-${assembly.assembly_id}`}
+                    >
+                      <Text style={styles.actionBtnPrimaryText}>Include</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() =>
+                        actions.markAlternate(assembly.assembly_id, { choice: 'exclude' })
+                      }
+                      disabled={phase === 'submitting'}
+                      accessibilityRole="button"
+                      accessibilityLabel="Exclude from base scope"
+                      style={({ hovered, pressed }: any) => [
+                        styles.actionBtn,
+                        styles.actionBtnSecondary,
+                        hovered && styles.actionBtnHover,
+                        pressed && styles.actionBtnPressed,
+                      ]}
+                      testID={`alternate-exclude-${assembly.assembly_id}`}
+                    >
+                      <Text style={styles.actionBtnSecondaryText}>Exclude</Text>
+                    </Pressable>
+                  </View>
+                }
+              />
+              {err ? (
+                <Text style={styles.errorInline}>{err.message}</Text>
+              ) : null}
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 14,
+  },
+  header: {
+    gap: 4,
+  },
+  headline: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.25,
+  },
+  subhead: {
+    fontSize: 11.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+    lineHeight: 16,
+  },
+  list: {
+    gap: 10,
+  },
+  alternateGroup: {
+    gap: 4,
+  },
+  trailingActions: {
+    flexDirection: 'column',
+    gap: 4,
+  },
+  actionBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 5,
+    borderWidth: 1,
+    minWidth: 70,
+    alignItems: 'center',
+    ...(Platform.OS === 'web'
+      ? ({ transition: 'background-color 150ms ease' } as any)
+      : {}),
+  },
+  actionBtnPrimary: {
+    backgroundColor: 'rgba(251,191,36,0.15)',
+    borderColor: 'rgba(251,191,36,0.55)',
+  },
+  actionBtnPrimaryText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#fbbf24',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  actionBtnSecondary: {
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderColor: 'rgba(255,255,255,0.10)',
+  },
+  actionBtnSecondaryText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.78)',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  actionBtnHover: {
+    opacity: 0.92,
+  },
+  actionBtnPressed: {
+    opacity: 0.78,
+  },
+  errorInline: {
+    fontSize: 10.5,
+    color: '#ff6b6b',
+    paddingHorizontal: 12,
+    letterSpacing: -0.05,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 380,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/AssemblyRow.tsx
+++ b/components/service-hub/estimate-studio/scope/AssemblyRow.tsx
@@ -1,0 +1,105 @@
+/**
+ * AssemblyRow — Wave 7.
+ *
+ * Shared row primitive used by IncludedWorkCard / NotInBaseCard /
+ * AlternatesCard. Flat-premium card geometry that lines up assembly type,
+ * quantity, unit, and a TruthBadge.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { BlueprintAssembly } from '@/lib/api/blueprintsApi';
+import { TruthBadge } from './TruthBadge';
+
+interface Props {
+  assembly: BlueprintAssembly;
+  /** Optional right-side trailing element (e.g. action buttons). */
+  trailing?: React.ReactNode;
+  testIDPrefix?: string;
+}
+
+export function AssemblyRow({
+  assembly,
+  trailing,
+  testIDPrefix = 'assembly-row',
+}: Props): React.ReactElement {
+  return (
+    <View
+      style={styles.row}
+      testID={`${testIDPrefix}-${assembly.assembly_id}`}
+    >
+      <View style={styles.body}>
+        <Text style={styles.label} numberOfLines={2}>
+          {assembly.label}
+        </Text>
+        <View style={styles.metaRow}>
+          <Text style={styles.quantity}>
+            {_formatQuantity(assembly.quantity)} {assembly.unit}
+          </Text>
+          <TruthBadge
+            truth={assembly.truth}
+            confidence={assembly.confidence}
+          />
+        </View>
+        {assembly.alternate_note ? (
+          <Text style={styles.alternateNote} numberOfLines={3}>
+            {assembly.alternate_note}
+          </Text>
+        ) : null}
+      </View>
+      {trailing ? <View style={styles.trailing}>{trailing}</View> : null}
+    </View>
+  );
+}
+
+function _formatQuantity(q: number): string {
+  if (Number.isInteger(q)) return q.toLocaleString();
+  return q.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+  },
+  body: {
+    flex: 1,
+    gap: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  quantity: {
+    fontSize: 11.5,
+    color: 'rgba(255,255,255,0.65)',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.05,
+  },
+  alternateNote: {
+    fontSize: 11.5,
+    fontStyle: 'italic',
+    color: 'rgba(255,255,255,0.55)',
+    lineHeight: 16,
+  },
+  trailing: {
+    alignItems: 'flex-end',
+    justifyContent: 'flex-start',
+    gap: 6,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/IncludedWorkCard.tsx
+++ b/components/service-hub/estimate-studio/scope/IncludedWorkCard.tsx
@@ -1,0 +1,120 @@
+/**
+ * IncludedWorkCard — Wave 7.
+ *
+ * Renders the assemblies that ARE in the base scope. Default Scope tab
+ * card after Story. Each row shows the assembly label, quantity + unit,
+ * and a TruthBadge (mostly observed / derived).
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintAssembly } from '@/lib/api/blueprintsApi';
+import { AssemblyRow } from './AssemblyRow';
+
+interface Props {
+  assemblies: BlueprintAssembly[];
+}
+
+export function IncludedWorkCard({ assemblies }: Props): React.ReactElement {
+  const included = assemblies.filter((a) => a.in_base_scope);
+
+  if (included.length === 0) {
+    return (
+      <View style={styles.empty} testID="included-work-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="checkmark-circle-outline"
+            size={28}
+            color="rgba(255,255,255,0.55)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>No base-scope work yet</Text>
+        <Text style={styles.emptyBody}>
+          Once Drew finishes classifying the plan set, base-scope assemblies
+          will appear here.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="included-work-card"
+    >
+      <View style={styles.header}>
+        <Text style={styles.headline}>Included Work</Text>
+        <Text style={styles.subhead}>
+          {included.length} assembl{included.length === 1 ? 'y' : 'ies'} in base scope.
+        </Text>
+      </View>
+      <View style={styles.list}>
+        {included.map((assembly) => (
+          <AssemblyRow
+            key={assembly.assembly_id}
+            assembly={assembly}
+            testIDPrefix="included-row"
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 14,
+  },
+  header: {
+    gap: 4,
+  },
+  headline: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.25,
+  },
+  subhead: {
+    fontSize: 11.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+  },
+  list: {
+    gap: 8,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 360,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/MissingInputCard.tsx
+++ b/components/service-hub/estimate-studio/scope/MissingInputCard.tsx
@@ -1,0 +1,328 @@
+/**
+ * MissingInputCard — Wave 7.
+ *
+ * Single row in the MissingInputsList. Each row exposes three action
+ * buttons:
+ *
+ *   - Confirm in Field — collects a text/number value, calls
+ *     useBlueprintActions().confirmMissingInput() → POST resolve endpoint.
+ *     YELLOW tier — UI shows submitting / success / error states.
+ *   - RFI            — Wave 8+ stub (drafts an RFI email).
+ *   - Ask Tim        — Wave 8+ stub (hands the question to Tim Enterprise).
+ *
+ * On a successful confirm, the row collapses into a "Resolved" sub-state
+ * with a field_confirmed TruthBadge.
+ */
+import React, { useState } from 'react';
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintMissingInput } from '@/lib/api/blueprintsApi';
+import { TruthBadge } from './TruthBadge';
+import type { ActionPhase } from '@/hooks/useBlueprintActions';
+
+interface Props {
+  input: BlueprintMissingInput;
+  phase: ActionPhase;
+  error: { code: string; message: string } | null;
+  onConfirm: (value: string) => void;
+  onRequestRFI: () => void;
+}
+
+export function MissingInputCard({
+  input,
+  phase,
+  error,
+  onConfirm,
+  onRequestRFI,
+}: Props): React.ReactElement {
+  const [confirmOpen, setConfirmOpen] = useState<boolean>(false);
+  const [value, setValue] = useState<string>('');
+
+  const isResolved = input.status === 'resolved' || phase === 'success';
+  const isSubmitting = phase === 'submitting';
+
+  if (isResolved) {
+    return (
+      <View
+        style={[styles.row, styles.rowResolved]}
+        testID={`missing-input-${input.input_id}-resolved`}
+      >
+        <View style={styles.body}>
+          <View style={styles.titleRow}>
+            <Ionicons name="checkmark-circle" size={16} color="#4ade80" />
+            <Text style={styles.title} numberOfLines={2}>
+              {input.description}
+            </Text>
+          </View>
+          {input.resolved_value || value ? (
+            <Text style={styles.resolvedValue}>
+              Confirmed: {input.resolved_value ?? value}
+            </Text>
+          ) : null}
+          <TruthBadge truth="field_confirmed" />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.row} testID={`missing-input-${input.input_id}`}>
+      <View style={styles.body}>
+        <View style={styles.titleRow}>
+          <Ionicons name="alert-circle-outline" size={16} color="#fb923c" />
+          <Text style={styles.title} numberOfLines={3}>
+            {input.description}
+          </Text>
+          <TruthBadge truth="missing" />
+        </View>
+        {input.suggested_resolution ? (
+          <Text style={styles.suggestion}>{input.suggested_resolution}</Text>
+        ) : null}
+
+        {confirmOpen ? (
+          <View style={styles.confirmForm}>
+            <TextInput
+              value={value}
+              onChangeText={setValue}
+              placeholder="Enter confirmed value..."
+              placeholderTextColor="rgba(255,255,255,0.35)"
+              style={styles.input}
+              editable={!isSubmitting}
+              testID={`missing-input-${input.input_id}-text`}
+            />
+            <View style={styles.confirmActions}>
+              <Pressable
+                onPress={() => {
+                  setConfirmOpen(false);
+                  setValue('');
+                }}
+                disabled={isSubmitting}
+                accessibilityRole="button"
+                accessibilityLabel="Cancel confirmation"
+                style={({ hovered, pressed }: any) => [
+                  styles.actionBtn,
+                  styles.actionBtnSecondary,
+                  hovered && styles.actionBtnHover,
+                  pressed && styles.actionBtnPressed,
+                ]}
+              >
+                <Text style={styles.actionBtnSecondaryText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => onConfirm(value.trim())}
+                disabled={isSubmitting || value.trim().length === 0}
+                accessibilityRole="button"
+                accessibilityLabel="Submit confirmation"
+                style={({ hovered, pressed }: any) => [
+                  styles.actionBtn,
+                  styles.actionBtnPrimary,
+                  isSubmitting && styles.actionBtnDisabled,
+                  value.trim().length === 0 && styles.actionBtnDisabled,
+                  hovered && !isSubmitting && styles.actionBtnHover,
+                  pressed && styles.actionBtnPressed,
+                ]}
+                testID={`missing-input-${input.input_id}-submit`}
+              >
+                <Text style={styles.actionBtnPrimaryText}>
+                  {isSubmitting ? 'Confirming…' : 'Confirm'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.actionRow}>
+            <Pressable
+              onPress={() => setConfirmOpen(true)}
+              accessibilityRole="button"
+              accessibilityLabel="Confirm in field"
+              style={({ hovered, pressed }: any) => [
+                styles.actionBtn,
+                styles.actionBtnPrimary,
+                hovered && styles.actionBtnHover,
+                pressed && styles.actionBtnPressed,
+              ]}
+              testID={`missing-input-${input.input_id}-open-confirm`}
+            >
+              <Ionicons
+                name="checkmark-outline"
+                size={12}
+                color="#0b1220"
+              />
+              <Text style={styles.actionBtnPrimaryText}>Confirm in Field</Text>
+            </Pressable>
+            <Pressable
+              onPress={onRequestRFI}
+              accessibilityRole="button"
+              accessibilityLabel="Draft an RFI email"
+              style={({ hovered, pressed }: any) => [
+                styles.actionBtn,
+                styles.actionBtnSecondary,
+                hovered && styles.actionBtnHover,
+                pressed && styles.actionBtnPressed,
+              ]}
+              testID={`missing-input-${input.input_id}-rfi`}
+            >
+              <Ionicons
+                name="mail-outline"
+                size={12}
+                color="rgba(255,255,255,0.85)"
+              />
+              <Text style={styles.actionBtnSecondaryText}>RFI</Text>
+            </Pressable>
+            <View
+              style={[styles.actionBtn, styles.actionBtnDisabled]}
+              accessibilityRole="text"
+            >
+              <Ionicons
+                name="chatbubble-outline"
+                size={12}
+                color="rgba(255,255,255,0.45)"
+              />
+              <Text style={styles.actionBtnDisabledText}>Ask Tim (v2)</Text>
+            </View>
+          </View>
+        )}
+
+        {error ? (
+          <Text style={styles.errorText} testID={`missing-input-${input.input_id}-error`}>
+            {error.message}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 14,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,146,60,0.22)',
+  },
+  rowResolved: {
+    borderColor: 'rgba(74,222,128,0.30)',
+    backgroundColor: 'rgba(74,222,128,0.04)',
+  },
+  body: {
+    flex: 1,
+    gap: 8,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  title: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+    lineHeight: 18,
+  },
+  suggestion: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.60)',
+    lineHeight: 17,
+    letterSpacing: -0.05,
+    fontStyle: 'italic',
+  },
+  resolvedValue: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(74,222,128,0.95)',
+    letterSpacing: -0.05,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  confirmForm: {
+    gap: 8,
+  },
+  input: {
+    fontSize: 12.5,
+    color: 'rgba(255,255,255,0.95)',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 6,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.12)',
+    ...(Platform.OS === 'web' ? ({ outlineStyle: 'none' } as any) : {}),
+  },
+  confirmActions: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  actionBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 6,
+    borderWidth: 1,
+    ...(Platform.OS === 'web'
+      ? ({ transition: 'background-color 150ms ease' } as any)
+      : {}),
+  },
+  actionBtnPrimary: {
+    backgroundColor: '#fbbf24',
+    borderColor: '#fbbf24',
+  },
+  actionBtnPrimaryText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#0b1220',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+  actionBtnSecondary: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderColor: 'rgba(255,255,255,0.12)',
+  },
+  actionBtnSecondaryText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.85)',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+  actionBtnHover: {
+    opacity: 0.92,
+  },
+  actionBtnPressed: {
+    opacity: 0.78,
+  },
+  actionBtnDisabled: {
+    backgroundColor: 'rgba(255,255,255,0.025)',
+    borderColor: 'rgba(255,255,255,0.06)',
+    opacity: 0.55,
+  },
+  actionBtnDisabledText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.45)',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+  errorText: {
+    fontSize: 11,
+    color: '#ff6b6b',
+    letterSpacing: -0.05,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/MissingInputsList.tsx
+++ b/components/service-hub/estimate-studio/scope/MissingInputsList.tsx
@@ -1,0 +1,180 @@
+/**
+ * MissingInputsList — Wave 7.
+ *
+ * Lists blueprint_missing_inputs rows. Splits visually into Open and
+ * Resolved sub-sections so contractors can see progress. Each row is
+ * a MissingInputCard with the YELLOW-tier confirm flow.
+ */
+import React, { useMemo } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintMissingInput } from '@/lib/api/blueprintsApi';
+import { MissingInputCard } from './MissingInputCard';
+import type { UseBlueprintActionsResult } from '@/hooks/useBlueprintActions';
+
+interface Props {
+  projectId: string | null;
+  inputs: BlueprintMissingInput[];
+  actions: UseBlueprintActionsResult;
+  onConfirmed: () => void;
+}
+
+export function MissingInputsList({
+  projectId,
+  inputs,
+  actions,
+  onConfirmed,
+}: Props): React.ReactElement {
+  const { open, resolved } = useMemo(() => {
+    const o: BlueprintMissingInput[] = [];
+    const r: BlueprintMissingInput[] = [];
+    for (const input of inputs) {
+      if (input.status === 'resolved') r.push(input);
+      else o.push(input);
+    }
+    return { open: o, resolved: r };
+  }, [inputs]);
+
+  if (inputs.length === 0) {
+    return (
+      <View style={styles.empty} testID="missing-inputs-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="checkmark-done-circle-outline"
+            size={28}
+            color="rgba(74,222,128,0.85)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>No missing inputs</Text>
+        <Text style={styles.emptyBody}>
+          Either the plan set is complete, or REASON hasn't surfaced any
+          known-unknowns yet.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="missing-inputs-list"
+    >
+      {open.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            Open · {open.length}
+          </Text>
+          <View style={styles.list}>
+            {open.map((input) => (
+              <MissingInputCard
+                key={input.input_id}
+                input={input}
+                phase={actions.phaseFor(input.input_id)}
+                error={actions.errorFor(input.input_id)}
+                onConfirm={async (value) => {
+                  if (!projectId) return;
+                  const result = await actions.confirmMissingInput(
+                    projectId,
+                    input.input_id,
+                    value,
+                  );
+                  if (result) {
+                    onConfirmed();
+                  }
+                }}
+                onRequestRFI={() => {
+                  void actions.requestRFI(input.input_id);
+                }}
+              />
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      {resolved.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitleResolved}>
+            Resolved · {resolved.length}
+          </Text>
+          <View style={styles.list}>
+            {resolved.map((input) => (
+              <MissingInputCard
+                key={input.input_id}
+                input={input}
+                phase="success"
+                error={null}
+                onConfirm={() => {
+                  /* already resolved — no-op */
+                }}
+                onRequestRFI={() => {
+                  /* already resolved — no-op */
+                }}
+              />
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 18,
+  },
+  section: {
+    gap: 10,
+  },
+  sectionTitle: {
+    fontSize: 10,
+    fontWeight: '800',
+    color: '#fb923c',
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+  },
+  sectionTitleResolved: {
+    fontSize: 10,
+    fontWeight: '800',
+    color: '#4ade80',
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+  },
+  list: {
+    gap: 10,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(74,222,128,0.05)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(74,222,128,0.22)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 380,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/NotInBaseCard.tsx
+++ b/components/service-hub/estimate-studio/scope/NotInBaseCard.tsx
@@ -1,0 +1,122 @@
+/**
+ * NotInBaseCard — Wave 7.
+ *
+ * Renders assemblies explicitly excluded from the base scope — alternates,
+ * owner-choice items, or work the LLM flagged as out-of-scope. Same flat
+ * card geometry as IncludedWorkCard.
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintAssembly } from '@/lib/api/blueprintsApi';
+import { AssemblyRow } from './AssemblyRow';
+
+interface Props {
+  assemblies: BlueprintAssembly[];
+}
+
+export function NotInBaseCard({ assemblies }: Props): React.ReactElement {
+  const excluded = assemblies.filter((a) => !a.in_base_scope);
+
+  if (excluded.length === 0) {
+    return (
+      <View style={styles.empty} testID="not-in-base-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="close-circle-outline"
+            size={28}
+            color="rgba(255,255,255,0.55)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>Nothing excluded</Text>
+        <Text style={styles.emptyBody}>
+          Drew didn't flag any assemblies as out-of-scope or owner-choice
+          alternates. Anything excluded later (e.g. via Alternates) will land here.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="not-in-base-card"
+    >
+      <View style={styles.header}>
+        <Text style={styles.headline}>Not in Base Scope</Text>
+        <Text style={styles.subhead}>
+          {excluded.length} assembl{excluded.length === 1 ? 'y' : 'ies'} excluded
+          from base. Move to Alternates to bid as add-ons.
+        </Text>
+      </View>
+      <View style={styles.list}>
+        {excluded.map((assembly) => (
+          <AssemblyRow
+            key={assembly.assembly_id}
+            assembly={assembly}
+            testIDPrefix="excluded-row"
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 14,
+  },
+  header: {
+    gap: 4,
+  },
+  headline: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.25,
+  },
+  subhead: {
+    fontSize: 11.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+    lineHeight: 16,
+  },
+  list: {
+    gap: 8,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 380,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/ScopeTab.tsx
+++ b/components/service-hub/estimate-studio/scope/ScopeTab.tsx
@@ -1,0 +1,356 @@
+/**
+ * ScopeTab — Wave 7 orchestrator.
+ *
+ * Owner of the Scope UX. Mirrors the Wave 6A shell pattern:
+ *
+ *   - Top: project breadcrumb (address + last-updated timestamp)
+ *   - Optional: Wave 2.7 backend-deferred banner (when the GET endpoints
+ *     return 404; honest localhost behavior per the plan)
+ *   - Canvas: CanvasCardSwitcher hosts ONE focused card at a time
+ *   - Bottom: BottomChipStrip with 6 chips (Story / Included / Not in Base /
+ *     Missing Inputs / Alternates / Tariff Exposure)
+ *
+ * Empty state (no project uploaded yet): big illustration + CTA back to
+ * Plans & Photos.
+ *
+ * Law #7: render layer only. Data fetching lives in useBlueprintStory();
+ * mutations live in useBlueprintActions().
+ */
+import React, { useMemo, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useBlueprintUploadSnapshot } from '@/lib/blueprintUploadStore';
+import { useProjectAddress } from '@/hooks/useProjectAddress';
+import { useBlueprintStory } from '@/hooks/useBlueprintStory';
+import { useBlueprintActions } from '@/hooks/useBlueprintActions';
+import { CanvasCardSwitcher } from '../shell/CanvasCardSwitcher';
+import { BottomChipStrip, type BottomChip } from '../shell/BottomChipStrip';
+import { StoryPanel } from './StoryPanel';
+import { IncludedWorkCard } from './IncludedWorkCard';
+import { NotInBaseCard } from './NotInBaseCard';
+import { MissingInputsList } from './MissingInputsList';
+import { AlternatesCard } from './AlternatesCard';
+import { TariffExposureCard } from './TariffExposureCard';
+
+type CardKey =
+  | 'story'
+  | 'included'
+  | 'not-in-base'
+  | 'missing'
+  | 'alternates'
+  | 'tariff';
+
+const EMPTY_STATE_COPY = 'Drop a plan set in Plans & Photos to see the story here.';
+
+export function ScopeTab(): React.ReactElement {
+  const upload = useBlueprintUploadSnapshot();
+  const { address } = useProjectAddress();
+  const router = useRouter();
+  const projectId = upload.response?.project_id ?? null;
+  const story = useBlueprintStory(projectId);
+  const actions = useBlueprintActions();
+
+  const [activeCard, setActiveCard] = useState<CardKey>('story');
+
+  const includedCount = useMemo(
+    () => story.assemblies.filter((a) => a.in_base_scope).length,
+    [story.assemblies],
+  );
+  const excludedCount = story.assemblies.length - includedCount;
+  const openMissing = useMemo(
+    () => story.missingInputs.filter((m) => m.status === 'open').length,
+    [story.missingInputs],
+  );
+  const alternateCount = useMemo(
+    () => story.assemblies.filter((a) => a.alternate_note != null).length,
+    [story.assemblies],
+  );
+  const tariffCount = useMemo(
+    () => story.materials.filter((m) => m.tariff_flagged).length,
+    [story.materials],
+  );
+
+  // Empty state — no upload yet. Stage a clear path back to Plans & Photos.
+  if (!projectId) {
+    return (
+      <View style={styles.tab} testID="scope-tab-empty">
+        <View style={styles.emptyHost}>
+          <View style={styles.emptyIconCircle}>
+            <Ionicons
+              name="document-text-outline"
+              size={32}
+              color="rgba(255,255,255,0.55)"
+            />
+          </View>
+          <Text style={styles.emptyTitle}>No story yet</Text>
+          <Text style={styles.emptyBody}>{EMPTY_STATE_COPY}</Text>
+          <Pressable
+            onPress={() => router.push('/service-hub/estimate-studio/plans-photos')}
+            accessibilityRole="button"
+            accessibilityLabel="Go to Plans & Photos"
+            style={({ hovered, pressed }: any) => [
+              styles.emptyCta,
+              hovered && styles.emptyCtaHover,
+              pressed && styles.emptyCtaPressed,
+            ]}
+            testID="scope-tab-empty-cta"
+          >
+            <Ionicons name="cloud-upload-outline" size={14} color="#0b1220" />
+            <Text style={styles.emptyCtaText}>Go to Plans &amp; Photos</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  const chips: BottomChip<CardKey>[] = [
+    {
+      key: 'story',
+      icon: 'book-outline',
+      label: 'Story',
+      stat: story.story
+        ? `${Math.round(story.story.mean_confidence * 100)}% confidence`
+        : story.isPolling
+          ? 'Composing…'
+          : 'Waiting on REASON',
+    },
+    {
+      key: 'included',
+      icon: 'checkmark-done-outline',
+      label: 'Included Work',
+      stat: `${includedCount} assembl${includedCount === 1 ? 'y' : 'ies'}`,
+    },
+    {
+      key: 'not-in-base',
+      icon: 'close-circle-outline',
+      label: 'Not in Base',
+      stat: `${excludedCount} excluded`,
+    },
+    {
+      key: 'missing',
+      icon: 'help-circle-outline',
+      label: 'Missing Inputs',
+      stat: `${openMissing} open`,
+      badge: openMissing > 0 ? String(openMissing) : undefined,
+    },
+    {
+      key: 'alternates',
+      icon: 'swap-horizontal-outline',
+      label: 'Alternates',
+      stat: `${alternateCount} option${alternateCount === 1 ? '' : 's'}`,
+    },
+    {
+      key: 'tariff',
+      icon: 'pricetag-outline',
+      label: 'Tariff Exposure',
+      stat: `${tariffCount} flagged`,
+    },
+  ];
+
+  const cards: Record<CardKey, React.ReactNode> = {
+    story: (
+      <StoryPanel
+        story={story.story}
+        isPolling={story.isPolling}
+        onConfirmFact={(fact) => {
+          // Jump to Missing Inputs and focus the matching row.
+          if (fact.missing_input_id) {
+            setActiveCard('missing');
+          }
+        }}
+      />
+    ),
+    included: <IncludedWorkCard assemblies={story.assemblies} />,
+    'not-in-base': <NotInBaseCard assemblies={story.assemblies} />,
+    missing: (
+      <MissingInputsList
+        projectId={projectId}
+        inputs={story.missingInputs}
+        actions={actions}
+        onConfirmed={() => {
+          void story.refetch();
+        }}
+      />
+    ),
+    alternates: (
+      <AlternatesCard assemblies={story.assemblies} actions={actions} />
+    ),
+    tariff: <TariffExposureCard materials={story.materials} />,
+  };
+
+  return (
+    <View style={styles.tab} testID="scope-tab">
+      {/* Project breadcrumb. */}
+      <View style={styles.breadcrumb}>
+        <Ionicons name="location-outline" size={13} color="rgba(255,255,255,0.55)" />
+        <Text style={styles.breadcrumbAddress} numberOfLines={1}>
+          {address || 'Untitled project'}
+        </Text>
+        {story.story?.updated_at ? (
+          <Text style={styles.breadcrumbMeta}>
+            · updated {_relativeTime(story.story.updated_at)}
+          </Text>
+        ) : null}
+        {story.isPolling ? (
+          <Text style={styles.breadcrumbLive}>· reading…</Text>
+        ) : null}
+      </View>
+
+      {/* Wave 2.7 backend-not-deployed banner (Tonio: honest localhost UX). */}
+      {!story.backendDeployed ? (
+        <View
+          style={styles.banner}
+          accessibilityRole="alert"
+          testID="scope-tab-wave-banner"
+        >
+          <Ionicons
+            name="information-circle-outline"
+            size={13}
+            color="#fbbf24"
+          />
+          <Text style={styles.bannerText}>
+            Story rendering requires Wave 2.7 backend reads (PR pending merge).
+          </Text>
+        </View>
+      ) : null}
+
+      <View style={styles.canvas}>
+        <CanvasCardSwitcher
+          activeCardKey={activeCard}
+          cards={cards}
+          testID="scope-canvas-switcher"
+        />
+      </View>
+
+      <BottomChipStrip
+        chips={chips}
+        activeKey={activeCard}
+        onChange={setActiveCard}
+        testID="scope-chip-strip"
+      />
+    </View>
+  );
+}
+
+function _relativeTime(iso: string): string {
+  try {
+    const date = new Date(iso);
+    const delta = Date.now() - date.getTime();
+    if (delta < 60_000) return 'just now';
+    if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+    if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+    return date.toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+const styles = StyleSheet.create({
+  tab: {
+    flex: 1,
+    padding: 18,
+    gap: 12,
+  },
+  breadcrumb: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 4,
+    flexWrap: 'wrap',
+  },
+  breadcrumbAddress: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.85)',
+    letterSpacing: -0.1,
+  },
+  breadcrumbMeta: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.50)',
+    letterSpacing: -0.05,
+  },
+  breadcrumbLive: {
+    fontSize: 11,
+    color: '#fbbf24',
+    fontStyle: 'italic',
+    letterSpacing: -0.05,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: 'rgba(251,191,36,0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.22)',
+  },
+  bannerText: {
+    flex: 1,
+    fontSize: 10.5,
+    color: 'rgba(251,191,36,0.85)',
+    letterSpacing: -0.05,
+    lineHeight: 14,
+  },
+  canvas: {
+    flex: 1,
+    minHeight: 320,
+  },
+  emptyHost: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 14,
+    padding: 32,
+  },
+  emptyIconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.90)',
+    letterSpacing: -0.25,
+  },
+  emptyBody: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.60)',
+    textAlign: 'center',
+    maxWidth: 420,
+    lineHeight: 19,
+  },
+  emptyCta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 8,
+    backgroundColor: '#fbbf24',
+    borderWidth: 1,
+    borderColor: '#fbbf24',
+    marginTop: 4,
+  },
+  emptyCtaHover: {
+    opacity: 0.92,
+  },
+  emptyCtaPressed: {
+    opacity: 0.78,
+  },
+  emptyCtaText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#0b1220',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+});

--- a/components/service-hub/estimate-studio/scope/StoryPanel.tsx
+++ b/components/service-hub/estimate-studio/scope/StoryPanel.tsx
@@ -1,0 +1,361 @@
+/**
+ * StoryPanel — Wave 7.
+ *
+ * The plain-English story renderer. This is THE deliverable that matters
+ * most to a contractor on the Scope tab: a 90-second readable narrative
+ * with inline truth-tag chips next to each fact.
+ *
+ * Renders the phased markdown story from `BlueprintStory.phases`. Each
+ * phase is a collapsible section (TI buildout: Demo → MEP rough → Framing
+ * → Finishes). Inline `BlueprintStoryFact[]` are rendered as TruthBadge
+ * chips with a "Confirm in field" inline button next to `assumed` facts.
+ *
+ * Premium typography:
+ *   - Comfortable reading width (max 720px)
+ *   - Tight letter-spacing on body text
+ *   - Tabular numbers on confidence percentages
+ *
+ * Law #7: pure render. The Confirm-in-field affordance dispatches up via
+ * onConfirmFact — actual mutation lives in useBlueprintActions().
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type {
+  BlueprintStory,
+  BlueprintStoryFact,
+  BlueprintStoryPhase,
+} from '@/lib/api/blueprintsApi';
+import { TruthBadge } from './TruthBadge';
+
+interface Props {
+  story: BlueprintStory | null;
+  isPolling: boolean;
+  /** Invoked when the user taps "Confirm in field" next to an assumed fact. */
+  onConfirmFact: (fact: BlueprintStoryFact) => void;
+}
+
+const READING_MAX_WIDTH = 720;
+
+export function StoryPanel({ story, isPolling, onConfirmFact }: Props): React.ReactElement {
+  if (!story || story.phases.length === 0) {
+    return (
+      <View style={styles.empty} testID="story-panel-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="book-outline"
+            size={28}
+            color="rgba(255,255,255,0.55)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>
+          {isPolling ? 'Reading your plan set...' : 'No story yet'}
+        </Text>
+        <Text style={styles.emptyBody}>
+          {isPolling
+            ? 'REASON is composing the phased narrative. This usually takes 30–60 seconds.'
+            : 'Once the plan set has been classified, the project story will appear here in plain English.'}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="story-panel"
+    >
+      <View style={styles.column}>
+        <View style={styles.header}>
+          <Text style={styles.headline}>Project Story</Text>
+          <View style={styles.headlineMeta}>
+            <Text style={styles.headlineMetaText}>
+              {Math.round(story.mean_confidence * 100)}% mean confidence
+            </Text>
+            {story.updated_at ? (
+              <Text style={styles.headlineMetaText}>
+                · updated {_friendlyTime(story.updated_at)}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
+        {story.phases.map((phase, idx) => (
+          <PhaseSection
+            key={phase.key}
+            phase={phase}
+            phaseNumber={idx + 1}
+            onConfirmFact={onConfirmFact}
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+function PhaseSection({
+  phase,
+  phaseNumber,
+  onConfirmFact,
+}: {
+  phase: BlueprintStoryPhase;
+  phaseNumber: number;
+  onConfirmFact: (fact: BlueprintStoryFact) => void;
+}): React.ReactElement {
+  const [expanded, setExpanded] = useState<boolean>(true);
+  return (
+    <View
+      style={styles.phase}
+      testID={`story-phase-${phase.key}`}
+    >
+      <Pressable
+        onPress={() => setExpanded((v) => !v)}
+        accessibilityRole="button"
+        accessibilityLabel={`${phase.title} — ${expanded ? 'collapse' : 'expand'}`}
+        style={({ hovered, pressed }: any) => [
+          styles.phaseHeader,
+          hovered && styles.phaseHeaderHover,
+          pressed && styles.phaseHeaderPressed,
+        ]}
+      >
+        <View style={styles.phaseNumber}>
+          <Text style={styles.phaseNumberText}>{phaseNumber}</Text>
+        </View>
+        <Text style={styles.phaseTitle}>{phase.title}</Text>
+        <Ionicons
+          name={expanded ? 'chevron-down' : 'chevron-forward'}
+          size={16}
+          color="rgba(255,255,255,0.55)"
+        />
+      </Pressable>
+      {expanded ? (
+        <View style={styles.phaseBody}>
+          <Text style={styles.phaseBodyText}>{phase.body_md}</Text>
+          {phase.facts.length > 0 ? (
+            <View style={styles.factWrap}>
+              {phase.facts.map((fact) => (
+                <FactChip
+                  key={fact.key}
+                  fact={fact}
+                  onConfirm={() => onConfirmFact(fact)}
+                />
+              ))}
+            </View>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function FactChip({
+  fact,
+  onConfirm,
+}: {
+  fact: BlueprintStoryFact;
+  onConfirm: () => void;
+}): React.ReactElement {
+  const isAssumed = fact.truth === 'assumed' || fact.truth === 'missing';
+  return (
+    <View style={styles.factRow} testID={`story-fact-${fact.key}`}>
+      <Text style={styles.factLabel}>{fact.label}</Text>
+      <TruthBadge truth={fact.truth} confidence={fact.confidence} />
+      {isAssumed ? (
+        <Pressable
+          onPress={onConfirm}
+          accessibilityRole="button"
+          accessibilityLabel={`Confirm ${fact.label} in field`}
+          style={({ hovered, pressed }: any) => [
+            styles.confirmInline,
+            hovered && styles.confirmInlineHover,
+            pressed && styles.confirmInlinePressed,
+          ]}
+          testID={`confirm-fact-${fact.key}`}
+        >
+          <Ionicons name="checkmark-outline" size={11} color="#fbbf24" />
+          <Text style={styles.confirmInlineText}>Confirm in field</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function _friendlyTime(iso: string): string {
+  try {
+    const date = new Date(iso);
+    const delta = Date.now() - date.getTime();
+    if (delta < 60_000) return 'just now';
+    if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+    if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+    return date.toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    alignItems: 'center',
+    padding: 24,
+  },
+  column: {
+    width: '100%',
+    maxWidth: READING_MAX_WIDTH,
+    gap: 18,
+  },
+  header: {
+    gap: 4,
+  },
+  headline: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    letterSpacing: -0.4,
+    ...(Platform.OS === 'web'
+      ? ({ fontFamily: 'ui-serif, Georgia, serif' } as any)
+      : {}),
+  },
+  headlineMeta: {
+    flexDirection: 'row',
+    gap: 6,
+    alignItems: 'center',
+  },
+  headlineMetaText: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+    fontVariant: ['tabular-nums'],
+  },
+  phase: {
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    overflow: 'hidden',
+  },
+  phaseHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: 'rgba(255,255,255,0.025)',
+  },
+  phaseHeaderHover: {
+    backgroundColor: 'rgba(255,255,255,0.045)',
+  },
+  phaseHeaderPressed: {
+    opacity: 0.85,
+  },
+  phaseNumber: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: 'rgba(251,191,36,0.15)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.45)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  phaseNumberText: {
+    fontSize: 11,
+    fontWeight: '800',
+    color: '#fbbf24',
+    fontVariant: ['tabular-nums'],
+  },
+  phaseTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.2,
+  },
+  phaseBody: {
+    padding: 16,
+    gap: 12,
+  },
+  phaseBodyText: {
+    fontSize: 13.5,
+    lineHeight: 21,
+    color: 'rgba(255,255,255,0.85)',
+    letterSpacing: -0.1,
+    ...(Platform.OS === 'web'
+      ? ({ fontFamily: 'ui-serif, Georgia, serif' } as any)
+      : {}),
+  },
+  factWrap: {
+    gap: 6,
+    paddingTop: 6,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(255,255,255,0.05)',
+  },
+  factRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  factLabel: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.78)',
+    letterSpacing: -0.05,
+  },
+  confirmInline: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 5,
+    backgroundColor: 'rgba(251,191,36,0.08)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,191,36,0.32)',
+  },
+  confirmInlineHover: {
+    backgroundColor: 'rgba(251,191,36,0.14)',
+  },
+  confirmInlinePressed: {
+    opacity: 0.85,
+  },
+  confirmInlineText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#fbbf24',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 380,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/TariffExposureCard.tsx
+++ b/components/service-hub/estimate-studio/scope/TariffExposureCard.tsx
@@ -1,0 +1,338 @@
+/**
+ * TariffExposureCard — Wave 7.
+ *
+ * Premium summary card that highlights tariff-flagged materials and their
+ * estimated $ impact. Drives the contractor's attention to the line items
+ * that are most exposed to Section 232 (steel / aluminum) and softwood
+ * lumber tariffs.
+ *
+ * Wave 5 PROCURE is what populates `tariff_impact_usd`. When PROCURE
+ * hasn't run yet, the per-flag count + per-material list still render,
+ * but the $ impact shows "—" with a tiny "Tariff data ready when PROCURE
+ * completes" note.
+ */
+import React, { useMemo } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { BlueprintMaterial } from '@/lib/api/blueprintsApi';
+import { TruthBadge } from './TruthBadge';
+
+interface Props {
+  materials: BlueprintMaterial[];
+}
+
+interface Bucket {
+  flag: string;
+  items: BlueprintMaterial[];
+  totalUsd: number | null;
+}
+
+export function TariffExposureCard({ materials }: Props): React.ReactElement {
+  const buckets = useMemo<Bucket[]>(() => {
+    const map = new Map<string, BlueprintMaterial[]>();
+    for (const mat of materials) {
+      if (!mat.tariff_flagged) continue;
+      const flag = mat.tariff_note ?? 'Unclassified tariff';
+      const existing = map.get(flag) ?? [];
+      existing.push(mat);
+      map.set(flag, existing);
+    }
+    return Array.from(map.entries())
+      .map(([flag, items]) => {
+        let total: number | null = null;
+        for (const m of items) {
+          if (typeof m.tariff_impact_usd === 'number') {
+            total = (total ?? 0) + m.tariff_impact_usd;
+          }
+        }
+        return { flag, items, totalUsd: total };
+      })
+      .sort((a, b) => b.items.length - a.items.length);
+  }, [materials]);
+
+  const totalFlaggedCount = buckets.reduce((sum, b) => sum + b.items.length, 0);
+  const overallUsd = buckets.reduce<number | null>((sum, b) => {
+    if (b.totalUsd == null) return sum;
+    return (sum ?? 0) + b.totalUsd;
+  }, null);
+
+  if (buckets.length === 0) {
+    return (
+      <View style={styles.empty} testID="tariff-exposure-empty">
+        <View style={styles.emptyIconCircle}>
+          <Ionicons
+            name="pricetag-outline"
+            size={28}
+            color="rgba(74,222,128,0.85)"
+          />
+        </View>
+        <Text style={styles.emptyTitle}>No tariff exposure</Text>
+        <Text style={styles.emptyBody}>
+          PROCURE didn't flag any materials in this plan set against current
+          Section 232 or softwood lumber tariff schedules.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.host}
+      contentContainerStyle={styles.scrollContent}
+      testID="tariff-exposure-card"
+    >
+      <View style={styles.summary}>
+        <View style={styles.summaryRow}>
+          <Text style={styles.summaryLabel}>Flagged Materials</Text>
+          <Text style={styles.summaryValue}>{totalFlaggedCount}</Text>
+        </View>
+        <View style={styles.summaryRow}>
+          <Text style={styles.summaryLabel}>Est. Tariff Impact</Text>
+          <Text style={styles.summaryValue}>
+            {overallUsd != null
+              ? `$${overallUsd.toLocaleString(undefined, {
+                  maximumFractionDigits: 0,
+                })}`
+              : '—'}
+          </Text>
+        </View>
+        {overallUsd == null ? (
+          <Text style={styles.summaryHint}>
+            Tariff data ready when PROCURE completes.
+          </Text>
+        ) : null}
+      </View>
+
+      <View style={styles.buckets}>
+        {buckets.map((bucket) => (
+          <View
+            key={bucket.flag}
+            style={styles.bucket}
+            testID={`tariff-bucket-${_slugify(bucket.flag)}`}
+          >
+            <View style={styles.bucketHeader}>
+              <Ionicons
+                name="alert-outline"
+                size={14}
+                color="#fb923c"
+              />
+              <Text style={styles.bucketFlag}>{bucket.flag}</Text>
+              <Text style={styles.bucketCount}>
+                {bucket.items.length} item{bucket.items.length === 1 ? '' : 's'}
+              </Text>
+              {bucket.totalUsd != null ? (
+                <Text style={styles.bucketUsd}>
+                  $
+                  {bucket.totalUsd.toLocaleString(undefined, {
+                    maximumFractionDigits: 0,
+                  })}
+                </Text>
+              ) : null}
+            </View>
+            <View style={styles.bucketList}>
+              {bucket.items.map((mat) => (
+                <View
+                  key={mat.material_id}
+                  style={styles.materialRow}
+                  testID={`tariff-material-${mat.material_id}`}
+                >
+                  <View style={styles.materialBody}>
+                    <Text style={styles.materialLabel} numberOfLines={2}>
+                      {mat.label}
+                    </Text>
+                    <View style={styles.materialMeta}>
+                      <Text style={styles.materialQty}>
+                        {mat.quantity.toLocaleString()} {mat.unit}
+                      </Text>
+                      <TruthBadge truth={mat.truth} />
+                      {mat.supplier_hint ? (
+                        <Text style={styles.materialSupplier} numberOfLines={1}>
+                          · {mat.supplier_hint}
+                        </Text>
+                      ) : null}
+                    </View>
+                  </View>
+                  {typeof mat.tariff_impact_usd === 'number' ? (
+                    <Text style={styles.materialUsd}>
+                      $
+                      {mat.tariff_impact_usd.toLocaleString(undefined, {
+                        maximumFractionDigits: 0,
+                      })}
+                    </Text>
+                  ) : (
+                    <Text style={styles.materialUsdPending}>—</Text>
+                  )}
+                </View>
+              ))}
+            </View>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+function _slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 16,
+  },
+  summary: {
+    padding: 16,
+    borderRadius: 10,
+    backgroundColor: 'rgba(251,146,60,0.05)',
+    borderWidth: 1,
+    borderColor: 'rgba(251,146,60,0.25)',
+    gap: 8,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+  },
+  summaryLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.65)',
+    letterSpacing: 1.0,
+    textTransform: 'uppercase',
+  },
+  summaryValue: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.3,
+  },
+  summaryHint: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.50)',
+    fontStyle: 'italic',
+    letterSpacing: -0.05,
+  },
+  buckets: {
+    gap: 14,
+  },
+  bucket: {
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.02)',
+    overflow: 'hidden',
+  },
+  bucketHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(255,255,255,0.06)',
+  },
+  bucketFlag: {
+    flex: 1,
+    fontSize: 12.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.92)',
+    letterSpacing: -0.1,
+  },
+  bucketCount: {
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+  },
+  bucketUsd: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+  },
+  bucketList: {
+    gap: 1,
+  },
+  materialRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 12,
+    backgroundColor: 'rgba(0,0,0,0.10)',
+  },
+  materialBody: {
+    flex: 1,
+    gap: 4,
+  },
+  materialLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.05,
+  },
+  materialMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  materialQty: {
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    fontVariant: ['tabular-nums'],
+  },
+  materialSupplier: {
+    flexShrink: 1,
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.45)',
+  },
+  materialUsd: {
+    fontSize: 12.5,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+  },
+  materialUsdPending: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.35)',
+    fontVariant: ['tabular-nums'],
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 28,
+  },
+  emptyIconCircle: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: 'rgba(74,222,128,0.05)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(74,222,128,0.22)',
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: -0.2,
+  },
+  emptyBody: {
+    fontSize: 12,
+    color: 'rgba(255,255,255,0.55)',
+    textAlign: 'center',
+    maxWidth: 380,
+    lineHeight: 17,
+  },
+});

--- a/components/service-hub/estimate-studio/scope/TruthBadge.tsx
+++ b/components/service-hub/estimate-studio/scope/TruthBadge.tsx
@@ -1,0 +1,153 @@
+/**
+ * TruthBadge — Wave 7.
+ *
+ * Tiny color-coded chip that renders a TruthClass inline. Used throughout
+ * the Scope tab next to story facts, assemblies, materials, and missing
+ * input descriptions so contractors can instantly tell what's solid vs
+ * what needs field confirmation.
+ *
+ * Palette (premium dark theme):
+ *   observed         — teal     (verified off a sheet)
+ *   derived          — blue     (computed from observed facts)
+ *   assumed          — amber    (LLM best-guess, needs confirmation)
+ *   missing          — orange   (known-unknown, must be resolved)
+ *   field_confirmed  — green    (owner/contractor confirmed in field)
+ *   vendor_confirmed — emerald  (supplier quote pinned the fact)
+ *   permit_confirmed — purple   (permit / inspection record pinned)
+ *
+ * Law #7: pure render — no fetch, no decision.
+ */
+import React from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import type { TruthClass } from '@/lib/api/blueprintsApi';
+
+interface Props {
+  truth: TruthClass;
+  /** Optional 0..1 confidence — rendered inline when present. */
+  confidence?: number;
+  /** Optional custom label override. Defaults to the truth class name. */
+  label?: string;
+  /** Compact variant — smaller padding + font. */
+  size?: 'sm' | 'md';
+  testID?: string;
+}
+
+interface TruthStyle {
+  fg: string;
+  bg: string;
+  border: string;
+  label: string;
+}
+
+const TRUTH_STYLES: Record<TruthClass, TruthStyle> = {
+  observed: {
+    fg: '#2dd4bf',
+    bg: 'rgba(45,212,191,0.10)',
+    border: 'rgba(45,212,191,0.45)',
+    label: 'observed',
+  },
+  derived: {
+    fg: '#60a5fa',
+    bg: 'rgba(96,165,250,0.10)',
+    border: 'rgba(96,165,250,0.45)',
+    label: 'derived',
+  },
+  assumed: {
+    fg: '#fbbf24',
+    bg: 'rgba(251,191,36,0.10)',
+    border: 'rgba(251,191,36,0.55)',
+    label: 'assumed',
+  },
+  missing: {
+    fg: '#fb923c',
+    bg: 'rgba(251,146,60,0.10)',
+    border: 'rgba(251,146,60,0.55)',
+    label: 'missing',
+  },
+  field_confirmed: {
+    fg: '#4ade80',
+    bg: 'rgba(74,222,128,0.10)',
+    border: 'rgba(74,222,128,0.45)',
+    label: 'field confirmed',
+  },
+  vendor_confirmed: {
+    fg: '#34d399',
+    bg: 'rgba(52,211,153,0.10)',
+    border: 'rgba(52,211,153,0.45)',
+    label: 'vendor confirmed',
+  },
+  permit_confirmed: {
+    fg: '#c084fc',
+    bg: 'rgba(192,132,252,0.10)',
+    border: 'rgba(192,132,252,0.45)',
+    label: 'permit confirmed',
+  },
+};
+
+export function getTruthStyle(truth: TruthClass): TruthStyle {
+  return TRUTH_STYLES[truth] ?? TRUTH_STYLES.assumed;
+}
+
+export function TruthBadge({
+  truth,
+  confidence,
+  label,
+  size = 'sm',
+  testID,
+}: Props): React.ReactElement {
+  const style = getTruthStyle(truth);
+  const text = label ?? style.label;
+  const showConf =
+    typeof confidence === 'number' &&
+    (truth === 'derived' || truth === 'assumed');
+  return (
+    <View
+      style={[
+        styles.badge,
+        size === 'md' && styles.badgeMd,
+        { backgroundColor: style.bg, borderColor: style.border },
+      ]}
+      testID={testID ?? `truth-badge-${truth}`}
+    >
+      <Text
+        style={[
+          styles.label,
+          size === 'md' && styles.labelMd,
+          { color: style.fg },
+        ]}
+      >
+        {text}
+        {showConf ? ` ${confidence!.toFixed(2)}` : ''}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 1,
+    ...(Platform.OS === 'web'
+      ? ({ transition: 'background-color 150ms ease' } as any)
+      : {}),
+  },
+  badgeMd: {
+    paddingHorizontal: 9,
+    paddingVertical: 3,
+    borderRadius: 5,
+  },
+  label: {
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+    fontVariant: ['tabular-nums'],
+  },
+  labelMd: {
+    fontSize: 10.5,
+    letterSpacing: 0.6,
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/ScopeContextPayload.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/ScopeContextPayload.tsx
@@ -1,0 +1,364 @@
+/**
+ * ScopeContextPayload — Wave 7.
+ *
+ * Tim Rail Context tab payload for the Scope route. Sections:
+ *
+ *   - 🚦 Pipeline status (5-stage indicator — Wave 6A UploadProgressInline)
+ *   - 📊 Story confidence % (project-level mean_confidence)
+ *   - 📈 Truth distribution bar
+ *   - ⚠️ Missing inputs (count + clickable hint)
+ *   - 🔁 Linked destinations (Materials / Takeoff / Estimate launchers)
+ *   - 🏷️ Tariff exposure summary
+ *
+ * Property facts stay rendered separately by TimRailContextTab below this
+ * component (per the Wave 6A pattern with PlansPhotosContextPayload).
+ *
+ * Law #7: pure render. Hooks fetch their own state.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useBlueprintUploadSnapshot } from '@/lib/blueprintUploadStore';
+import { useBlueprintStory } from '@/hooks/useBlueprintStory';
+import { ContextTabPayload, type ContextSection } from '../shell/ContextTabPayload';
+import { UploadProgressInline } from '../plans-photos/UploadProgressInline';
+import type { TruthClass } from '@/lib/api/blueprintsApi';
+import { getTruthStyle } from '../scope/TruthBadge';
+
+interface Props {
+  projectId?: string | null;
+}
+
+// Order matters for the visual bar — most-trusted on the left.
+const TRUTH_ORDER: TruthClass[] = [
+  'observed',
+  'field_confirmed',
+  'vendor_confirmed',
+  'permit_confirmed',
+  'derived',
+  'assumed',
+  'missing',
+];
+
+export function ScopeContextPayload({ projectId }: Props): React.ReactElement {
+  const router = useRouter();
+  const snap = useBlueprintUploadSnapshot();
+  const effectiveProjectId = projectId ?? snap.response?.project_id ?? null;
+  const story = useBlueprintStory(effectiveProjectId);
+
+  const confidencePct = story.story
+    ? Math.round(story.story.mean_confidence * 100)
+    : null;
+
+  const truthEntries = TRUTH_ORDER.map((tc) => ({
+    truth: tc,
+    count: story.story?.truth_distribution?.[tc] ?? 0,
+  })).filter((e) => e.count > 0);
+  const truthTotal = truthEntries.reduce((sum, e) => sum + e.count, 0);
+
+  const openMissing = story.missingInputs.filter((m) => m.status === 'open').length;
+  const tariffFlagged = story.materials.filter((m) => m.tariff_flagged).length;
+  const tariffUsd = story.materials.reduce<number | null>((sum, m) => {
+    if (typeof m.tariff_impact_usd === 'number') return (sum ?? 0) + m.tariff_impact_usd;
+    return sum;
+  }, null);
+
+  const sections: ContextSection[] = [
+    {
+      key: 'pipeline',
+      title: 'Pipeline Status',
+      render: () => (
+        <UploadProgressInline
+          stages={snap.stageProgress}
+          layout="vertical"
+          testID="scope-context-pipeline-status"
+        />
+      ),
+    },
+    {
+      key: 'confidence',
+      title: 'Story Confidence',
+      render: () => (
+        <View style={styles.confidenceRow} testID="scope-context-confidence">
+          <Text style={styles.confidenceValue}>
+            {confidencePct != null ? `${confidencePct}%` : '—'}
+          </Text>
+          <Text style={styles.confidenceLabel}>mean</Text>
+        </View>
+      ),
+    },
+    {
+      key: 'truth-distribution',
+      title: 'Truth Distribution',
+      render: () => {
+        if (truthTotal === 0) {
+          return (
+            <Text style={styles.empty}>
+              {story.isPolling ? 'Reading plan set…' : 'No facts yet.'}
+            </Text>
+          );
+        }
+        return (
+          <View style={styles.truthBar} testID="scope-context-truth-bar">
+            <View style={styles.truthBarTrack}>
+              {truthEntries.map((entry) => {
+                const pct = (entry.count / truthTotal) * 100;
+                const s = getTruthStyle(entry.truth);
+                return (
+                  <View
+                    key={entry.truth}
+                    style={{
+                      width: `${pct}%`,
+                      height: '100%',
+                      backgroundColor: s.fg,
+                    }}
+                    testID={`scope-context-truth-seg-${entry.truth}`}
+                  />
+                );
+              })}
+            </View>
+            <View style={styles.truthLegend}>
+              {truthEntries.map((entry) => {
+                const s = getTruthStyle(entry.truth);
+                return (
+                  <View key={entry.truth} style={styles.truthLegendItem}>
+                    <View
+                      style={[styles.truthLegendDot, { backgroundColor: s.fg }]}
+                    />
+                    <Text style={styles.truthLegendText}>
+                      {s.label} · {entry.count}
+                    </Text>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        );
+      },
+    },
+    {
+      key: 'missing-inputs',
+      title: 'Missing Inputs',
+      render: () => (
+        <View style={styles.missingRow} testID="scope-context-missing">
+          <View style={styles.missingStat}>
+            <Text style={styles.missingValue}>{openMissing}</Text>
+            <Text style={styles.missingLabel}>open</Text>
+          </View>
+          <Text style={styles.missingHint}>
+            {openMissing === 0
+              ? 'All known-unknowns resolved.'
+              : 'Open the Missing Inputs chip to confirm in field.'}
+          </Text>
+        </View>
+      ),
+    },
+    {
+      key: 'linked-destinations',
+      title: 'Linked Destinations',
+      render: () => (
+        <View style={styles.destWrap}>
+          {(
+            [
+              { label: 'Materials', icon: 'cube-outline', path: '/service-hub/estimate-studio/materials' },
+              { label: 'Takeoff', icon: 'cut-outline', path: '/service-hub/estimate-studio/takeoff' },
+              { label: 'Estimate', icon: 'calculator-outline', path: '/service-hub/estimate-studio/estimate' },
+            ] as const
+          ).map((dest) => (
+            <Pressable
+              key={dest.label}
+              onPress={() => router.push(dest.path)}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${dest.label}`}
+              style={({ hovered, pressed }: any) => [
+                styles.destBtn,
+                hovered && styles.destBtnHover,
+                pressed && styles.destBtnPressed,
+              ]}
+              testID={`scope-context-link-${dest.label.toLowerCase()}`}
+            >
+              <Ionicons
+                name={dest.icon}
+                size={13}
+                color="rgba(255,255,255,0.78)"
+              />
+              <Text style={styles.destBtnText}>{dest.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ),
+    },
+    {
+      key: 'tariff-exposure',
+      title: 'Tariff Exposure',
+      render: () => (
+        <View style={styles.tariffRow} testID="scope-context-tariff">
+          <View style={styles.tariffStat}>
+            <Text style={styles.tariffValue}>{tariffFlagged}</Text>
+            <Text style={styles.tariffLabel}>flagged</Text>
+          </View>
+          <Text style={styles.tariffUsd}>
+            {tariffUsd != null
+              ? `$${tariffUsd.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+              : '— pending PROCURE'}
+          </Text>
+        </View>
+      ),
+    },
+  ];
+
+  return <ContextTabPayload sections={sections} testID="scope-context-payload" />;
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.45)',
+    letterSpacing: -0.05,
+    paddingHorizontal: 4,
+  },
+  confidenceRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+    paddingHorizontal: 4,
+  },
+  confidenceValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.95)',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.4,
+  },
+  confidenceLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.50)',
+    letterSpacing: 1.0,
+    textTransform: 'uppercase',
+  },
+  truthBar: {
+    gap: 8,
+    paddingHorizontal: 2,
+  },
+  truthBarTrack: {
+    flexDirection: 'row',
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  truthLegend: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  truthLegendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  truthLegendDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+  },
+  truthLegendText: {
+    fontSize: 10,
+    color: 'rgba(255,255,255,0.65)',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: -0.05,
+  },
+  missingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 4,
+  },
+  missingStat: {
+    alignItems: 'center',
+    minWidth: 40,
+  },
+  missingValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+  },
+  missingLabel: {
+    fontSize: 8.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: 1.0,
+    textTransform: 'uppercase',
+  },
+  missingHint: {
+    flex: 1,
+    fontSize: 10.5,
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: -0.05,
+    lineHeight: 14,
+  },
+  destWrap: {
+    flexDirection: 'row',
+    gap: 6,
+    flexWrap: 'wrap',
+    paddingHorizontal: 2,
+  },
+  destBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 9,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+  },
+  destBtnHover: {
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderColor: 'rgba(255,255,255,0.16)',
+  },
+  destBtnPressed: {
+    opacity: 0.82,
+  },
+  destBtnText: {
+    fontSize: 10.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.85)',
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  },
+  tariffRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 4,
+  },
+  tariffStat: {
+    alignItems: 'center',
+    minWidth: 40,
+  },
+  tariffValue: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+  },
+  tariffLabel: {
+    fontSize: 8.5,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.55)',
+    letterSpacing: 1.0,
+    textTransform: 'uppercase',
+  },
+  tariffUsd: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#fb923c',
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
@@ -14,6 +14,7 @@ import { usePathname } from 'expo-router';
 import { PropertySummaryCard } from './PropertySummaryCard';
 import { MaterialsRouteContextCard } from './MaterialsRouteContextCard';
 import { PlansPhotosContextPayload } from './PlansPhotosContextPayload';
+import { ScopeContextPayload } from './ScopeContextPayload';
 import type { PropertyData } from '@/services/serviceHub/propertyDataApi';
 
 // Inject a one-shot stylesheet on web that hides the scrollbar inside
@@ -46,6 +47,8 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
     pathname.endsWith('/materials') || pathname.endsWith('/materials/');
   const isPlansPhotosTab =
     pathname.endsWith('/plans-photos') || pathname.endsWith('/plans-photos/');
+  const isScopeTab =
+    pathname.endsWith('/scope') || pathname.endsWith('/scope/');
 
   return (
     <ScrollView
@@ -91,6 +94,11 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
       {/* Plans & Photos payload: pipeline status + discipline counts + last
           upload. Renders null off-route. Property facts carry over below. */}
       {isPlansPhotosTab && <PlansPhotosContextPayload />}
+
+      {/* Scope payload (Wave 7): pipeline + confidence + truth distribution
+          + missing inputs + linked destinations + tariff summary. Property
+          facts carry over below as on Plans & Photos. */}
+      {isScopeTab && <ScopeContextPayload />}
 
       {/* Property facts hidden on Materials tab — that tab's context
           is the route + bundle, not the property valuation card. The

--- a/hooks/useBlueprintActions.ts
+++ b/hooks/useBlueprintActions.ts
@@ -1,0 +1,152 @@
+/**
+ * useBlueprintActions — Wave 7.
+ *
+ * Action handlers for the Scope tab — YELLOW-tier mutations that go through
+ * the Express proxy (capability-token round-trip).
+ *
+ * Actions:
+ *   - confirmMissingInput(inputId, value): POST /missing_inputs/:id/resolve
+ *   - markAlternate(alternateId, choice): Wave 7+ stub (no backend route yet)
+ *   - requestRFI(item): Wave 7+ stub (RFI email composer is Wave 8+)
+ *
+ * Law compliance:
+ *   Law #1 — UI never decides; the orchestrator owns the resolve action.
+ *   Law #2 — backend writes a blueprint_receipt on success.
+ *   Law #5 — capability token minted server-side, scope=resolve_missing_input.
+ *   Law #6 — officeId from session context, never user input.
+ */
+import { useCallback, useState } from 'react';
+import { useAuthFetch } from '@/lib/authenticatedFetch';
+import { useTenant } from '@/providers';
+import {
+  BlueprintsApiError,
+  resolveMissingInput,
+  type BlueprintMissingInput,
+} from '@/lib/api/blueprintsApi';
+
+export type ActionPhase = 'idle' | 'submitting' | 'success' | 'error';
+
+export interface AlternateChoice {
+  /** Choose: 'include' to move to base scope, 'exclude' for not-in-base. */
+  choice: 'include' | 'exclude';
+}
+
+export interface UseBlueprintActionsResult {
+  /** Per-action phase state, keyed by inputId / alternateId. */
+  phaseFor: (key: string) => ActionPhase;
+  errorFor: (key: string) => { code: string; message: string } | null;
+  confirmMissingInput: (
+    projectId: string,
+    inputId: string,
+    value: string,
+  ) => Promise<BlueprintMissingInput | null>;
+  markAlternate: (alternateId: string, choice: AlternateChoice) => Promise<void>;
+  requestRFI: (itemKey: string) => Promise<void>;
+}
+
+export function useBlueprintActions(): UseBlueprintActionsResult {
+  const { authenticatedFetch } = useAuthFetch();
+  const tenant = useTenant() as { officeId?: string };
+  const officeId = tenant.officeId ?? '';
+
+  const [phases, setPhases] = useState<Record<string, ActionPhase>>({});
+  const [errors, setErrors] = useState<Record<string, { code: string; message: string } | null>>(
+    {},
+  );
+
+  const setPhase = useCallback((key: string, phase: ActionPhase): void => {
+    setPhases((prev) => ({ ...prev, [key]: phase }));
+  }, []);
+
+  const setError = useCallback(
+    (key: string, err: { code: string; message: string } | null): void => {
+      setErrors((prev) => ({ ...prev, [key]: err }));
+    },
+    [],
+  );
+
+  const phaseFor = useCallback(
+    (key: string): ActionPhase => phases[key] ?? 'idle',
+    [phases],
+  );
+
+  const errorFor = useCallback(
+    (key: string): { code: string; message: string } | null => errors[key] ?? null,
+    [errors],
+  );
+
+  const confirmMissingInput = useCallback(
+    async (
+      projectId: string,
+      inputId: string,
+      value: string,
+    ): Promise<BlueprintMissingInput | null> => {
+      if (!projectId || !inputId || !officeId) {
+        setPhase(inputId, 'error');
+        setError(inputId, {
+          code: 'INVALID_INPUT',
+          message: 'Missing project, input id, or office context.',
+        });
+        return null;
+      }
+      setPhase(inputId, 'submitting');
+      setError(inputId, null);
+      try {
+        const result = await resolveMissingInput(
+          authenticatedFetch,
+          projectId,
+          inputId,
+          value,
+          officeId,
+        );
+        setPhase(inputId, 'success');
+        return result;
+      } catch (e) {
+        const code = e instanceof BlueprintsApiError ? e.code : 'UNKNOWN_ERROR';
+        const message = e instanceof Error ? e.message : 'Unknown error';
+        setPhase(inputId, 'error');
+        setError(inputId, { code, message });
+        return null;
+      }
+    },
+    [authenticatedFetch, officeId, setPhase, setError],
+  );
+
+  // Wave 7+ stubs — these are visual handlers only; no backend route yet.
+  // Surfaced so callers can wire optimistic state changes today; the actual
+  // mutation lands in a follow-up wave alongside the backend endpoint.
+  const markAlternate = useCallback(
+    async (alternateId: string, _choice: AlternateChoice): Promise<void> => {
+      setPhase(alternateId, 'submitting');
+      // Defer to next tick so the UI can show the submitting state.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      setPhase(alternateId, 'error');
+      setError(alternateId, {
+        code: 'NOT_IMPLEMENTED_WAVE_7_PLUS',
+        message: 'Marking alternates ships in a follow-up wave.',
+      });
+    },
+    [setPhase, setError],
+  );
+
+  const requestRFI = useCallback(
+    async (itemKey: string): Promise<void> => {
+      setPhase(itemKey, 'submitting');
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      setPhase(itemKey, 'error');
+      setError(itemKey, {
+        code: 'NOT_IMPLEMENTED_WAVE_8_PLUS',
+        message: 'RFI drafting ships in Wave 8+.',
+      });
+    },
+    [setPhase, setError],
+  );
+
+  return {
+    phaseFor,
+    errorFor,
+    confirmMissingInput,
+    markAlternate,
+    requestRFI,
+  };
+}

--- a/hooks/useBlueprintStory.ts
+++ b/hooks/useBlueprintStory.ts
@@ -1,0 +1,212 @@
+/**
+ * useBlueprintStory — Wave 7.
+ *
+ * Fetches the four REASON/PROCURE read endpoints in parallel for the Scope tab:
+ *   - GET /api/v1/blueprints/projects/:id/story
+ *   - GET /api/v1/blueprints/projects/:id/assemblies
+ *   - GET /api/v1/blueprints/projects/:id/materials
+ *   - GET /api/v1/blueprints/projects/:id/missing_inputs
+ *
+ * Polls every 2s while REASON is in_progress; stops on done/error/no-project.
+ * On 404 (Wave 2.7 backend not yet deployed), degrades to an empty state with
+ * `backendDeployed=false` — UI surfaces the deferred-backend banner.
+ *
+ * Law compliance:
+ *   Law #6 — `officeId` derives from the tenant context; never a user input.
+ *   Law #7 — pure data hook: no decisions, no side-effects beyond setState.
+ *   Law #9 — fetch errors logged with code only, never request bodies.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuthFetch } from '@/lib/authenticatedFetch';
+import { useTenant } from '@/providers';
+import {
+  BlueprintsApiError,
+  getAssemblies,
+  getMaterials,
+  getMissingInputs,
+  getStory,
+  type BlueprintAssembly,
+  type BlueprintMaterial,
+  type BlueprintMissingInput,
+  type BlueprintStory,
+  type TruthClass,
+} from '@/lib/api/blueprintsApi';
+
+export interface UseBlueprintStoryResult {
+  story: BlueprintStory | null;
+  assemblies: BlueprintAssembly[];
+  materials: BlueprintMaterial[];
+  missingInputs: BlueprintMissingInput[];
+  isLoading: boolean;
+  isPolling: boolean;
+  /** True iff backend Wave 2.7 endpoints are reachable (not 404).
+   *  Drives the "Story rendering requires Wave 2.7 backend reads" banner. */
+  backendDeployed: boolean;
+  error: { code: string; message: string } | null;
+  /** Manually refetch all four endpoints (e.g. after resolveMissingInput). */
+  refetch: () => Promise<void>;
+}
+
+const POLL_MS = 2000;
+
+export const EMPTY_TRUTH_DIST: Record<TruthClass, number> = {
+  observed: 0,
+  derived: 0,
+  assumed: 0,
+  missing: 0,
+  field_confirmed: 0,
+  vendor_confirmed: 0,
+  permit_confirmed: 0,
+};
+
+export function useBlueprintStory(projectId: string | null): UseBlueprintStoryResult {
+  const { authenticatedFetch } = useAuthFetch();
+  const tenant = useTenant() as { officeId?: string };
+  const officeId = tenant.officeId ?? '';
+
+  const [story, setStory] = useState<BlueprintStory | null>(null);
+  const [assemblies, setAssemblies] = useState<BlueprintAssembly[]>([]);
+  const [materials, setMaterials] = useState<BlueprintMaterial[]>([]);
+  const [missingInputs, setMissingInputs] = useState<BlueprintMissingInput[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [backendDeployed, setBackendDeployed] = useState<boolean>(true);
+  const [error, setError] = useState<{ code: string; message: string } | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchAll = useCallback(async (): Promise<void> => {
+    if (!projectId || !officeId) {
+      setStory(null);
+      setAssemblies([]);
+      setMaterials([]);
+      setMissingInputs([]);
+      setError(null);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [storyResult, assembliesResult, materialsResult, missingResult] =
+        await Promise.allSettled([
+          getStory(authenticatedFetch, projectId, officeId, controller.signal),
+          getAssemblies(authenticatedFetch, projectId, officeId, {}, controller.signal),
+          getMaterials(authenticatedFetch, projectId, officeId, {}, controller.signal),
+          getMissingInputs(authenticatedFetch, projectId, officeId, {}, controller.signal),
+        ]);
+
+      // 404 across-the-board means Wave 2.7 backend hasn't shipped yet.
+      const all404 = [storyResult, assembliesResult, materialsResult, missingResult].every(
+        (r) =>
+          r.status === 'rejected' &&
+          r.reason instanceof BlueprintsApiError &&
+          r.reason.status === 404,
+      );
+
+      if (all404) {
+        setBackendDeployed(false);
+        setStory(null);
+        setAssemblies([]);
+        setMaterials([]);
+        setMissingInputs([]);
+        return;
+      }
+
+      setBackendDeployed(true);
+
+      if (storyResult.status === 'fulfilled') {
+        setStory(storyResult.value);
+      } else if (
+        storyResult.reason instanceof BlueprintsApiError &&
+        storyResult.reason.status === 404
+      ) {
+        setStory(null);
+      } else if (storyResult.reason instanceof Error) {
+        setError({
+          code:
+            storyResult.reason instanceof BlueprintsApiError
+              ? storyResult.reason.code
+              : 'STORY_FETCH_FAILED',
+          message: storyResult.reason.message,
+        });
+      }
+
+      if (assembliesResult.status === 'fulfilled') {
+        setAssemblies(assembliesResult.value);
+      } else {
+        setAssemblies([]);
+      }
+
+      if (materialsResult.status === 'fulfilled') {
+        setMaterials(materialsResult.value);
+      } else {
+        setMaterials([]);
+      }
+
+      if (missingResult.status === 'fulfilled') {
+        setMissingInputs(missingResult.value);
+      } else {
+        setMissingInputs([]);
+      }
+    } catch (e) {
+      if ((e as Error).name === 'AbortError') return;
+      setError({
+        code: e instanceof BlueprintsApiError ? e.code : 'UNKNOWN_ERROR',
+        message: e instanceof Error ? e.message : 'Unknown fetch error',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authenticatedFetch, officeId, projectId]);
+
+  // Initial fetch + project_id change handler.
+  useEffect(() => {
+    void fetchAll();
+    return () => {
+      abortRef.current?.abort();
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [fetchAll]);
+
+  // 2s poll while REASON is in_progress.
+  const isPolling = story?.status === 'in_progress';
+  useEffect(() => {
+    if (!isPolling) {
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+      return;
+    }
+    pollTimerRef.current = setTimeout(() => {
+      void fetchAll();
+    }, POLL_MS);
+    return () => {
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [isPolling, fetchAll]);
+
+  return {
+    story,
+    assemblies,
+    materials,
+    missingInputs,
+    isLoading,
+    isPolling,
+    backendDeployed,
+    error,
+    refetch: fetchAll,
+  };
+}

--- a/lib/api/blueprintsApi.ts
+++ b/lib/api/blueprintsApi.ts
@@ -8,15 +8,15 @@
  * Wave 6A scope:
  *   - uploadBlueprint(): full INGEST + auto-chained CLASSIFY in one call.
  *
- * Wave 6.5 (deferred — backend GET endpoints not yet wired):
- *   - getProject(): GET /api/v1/blueprints/projects/:id
- *   - listSheets(): GET /api/v1/blueprints/projects/:id/sheets
- *   - getProjectStatus(): GET /api/v1/blueprints/projects/:id/status
+ * Wave 7 scope (this file):
+ *   - Project/sheet/status GETs (Wave 2.5 backend reads)
+ *   - Story / assemblies / materials / missing_inputs GETs (Wave 2.7)
+ *   - resolveMissingInput POST (Wave 2.7 — YELLOW tier; scope=
+ *     `blueprints:resolve_missing_input`)
  *
- * These three are declared with their full types so call-sites can be
- * sketched ahead of Wave 6.5 wiring, but the implementations throw
- * `NotImplementedError` until the backend reads land. See
- * docs/plans/serene-seeking-hollerith for the cross-wave plan.
+ * Until Wave 2.5 / 2.7 backend PRs merge, the Express proxy returns 404 for
+ * these routes. Callers (hooks) MUST catch `BlueprintsApiError.status === 404`
+ * and degrade to an empty render path. See docs/plans/serene-seeking-hollerith.
  *
  * Law compliance:
  *   Law #5 — capability token minted server-side by the Express proxy.
@@ -144,6 +144,103 @@ export interface BlueprintSheet {
 }
 
 // ---------------------------------------------------------------------------
+// Wave 7 — Story / Assemblies / Materials / Missing Inputs (REASON + PROCURE)
+// ---------------------------------------------------------------------------
+
+/** Confidence class for a fact in the story / assembly / material chain. */
+export type TruthClass =
+  | 'observed'
+  | 'derived'
+  | 'assumed'
+  | 'missing'
+  | 'field_confirmed'
+  | 'vendor_confirmed'
+  | 'permit_confirmed';
+
+/** A single phase of the project's work narrative. */
+export interface BlueprintStoryPhase {
+  key: string;
+  title: string;
+  /** Plain-English narrative markdown body. */
+  body_md: string;
+  facts: BlueprintStoryFact[];
+}
+
+/** A single inline fact in a phase narrative. Renders as a TruthBadge chip. */
+export interface BlueprintStoryFact {
+  key: string;
+  label: string;
+  truth: TruthClass;
+  /** Optional 0..1 confidence (derived / assumed). */
+  confidence?: number;
+  /** Optional missing_input_id when truth === 'assumed' or 'missing'. */
+  missing_input_id?: string | null;
+}
+
+export interface BlueprintStory {
+  project_id: string;
+  /** Overall project mean confidence (0..1). */
+  mean_confidence: number;
+  /** Counts by truth class for the truth-distribution bar. */
+  truth_distribution: Record<TruthClass, number>;
+  phases: BlueprintStoryPhase[];
+  updated_at: string | null;
+  /** REASON pipeline stage state — UI polls until 'done' or 'error'. */
+  status: 'pending' | 'in_progress' | 'done' | 'error';
+}
+
+/** An assembly line item Drew identified (e.g. "drywall partition"). */
+export interface BlueprintAssembly {
+  assembly_id: string;
+  assembly_type: string;
+  label: string;
+  quantity: number;
+  unit: string;
+  truth: TruthClass;
+  confidence?: number;
+  /** True if part of the base scope; false if alternate / not-in-base. */
+  in_base_scope: boolean;
+  alternate_note?: string | null;
+}
+
+/** A material line item Drew / PROCURE identified. */
+export interface BlueprintMaterial {
+  material_id: string;
+  label: string;
+  quantity: number;
+  unit: string;
+  truth: TruthClass;
+  tariff_flagged: boolean;
+  tariff_note?: string | null;
+  /** Estimated $ impact for the tariff line (PROCURE; null until Wave 5). */
+  tariff_impact_usd?: number | null;
+  supplier_hint?: string | null;
+}
+
+/** A known-unknown that needs field confirmation / RFI / owner input. */
+export interface BlueprintMissingInput {
+  input_id: string;
+  description: string;
+  suggested_resolution?: string | null;
+  status: 'open' | 'resolved';
+  resolved_value?: string | null;
+  resolved_at?: string | null;
+}
+
+export interface GetAssembliesOptions {
+  activeOnly?: boolean;
+}
+
+export interface GetMaterialsOptions {
+  tariffOnly?: boolean;
+  hasSupplier?: boolean;
+}
+
+export interface GetMissingInputsOptions {
+  unresolvedOnly?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // API functions
 // ---------------------------------------------------------------------------
 
@@ -242,47 +339,203 @@ export async function uploadBlueprint(
 }
 
 // ---------------------------------------------------------------------------
-// Wave 6.5 stubs — types declared, implementations throw
+// Wave 6.5 / Wave 7 — real GET clients (graceful 404 via BlueprintsApiError)
+//
+// The Express proxy + Python orchestrator endpoints land in:
+//   Wave 2.5 — GET /api/v1/blueprints/projects/:id, /sheets, /status
+//   Wave 2.7 — GET /story, /assemblies, /materials, /missing_inputs +
+//              POST /missing_inputs/:input_id/resolve
+//
+// Until those PRs merge, the proxy returns 404. Callers (hooks) must catch
+// `BlueprintsApiError.status === 404` and degrade to an empty render path
+// rather than treating it as a real failure.
 // ---------------------------------------------------------------------------
 
-/** Wave 6.5 — fetch a single project's metadata + progress.
- *  Throws until backend GET endpoint lands. */
+async function _getJson<T>(
+  authenticatedFetch: FetchFn,
+  url: string,
+  officeId: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  const resp = await authenticatedFetch(url, {
+    method: 'GET',
+    headers: { 'X-Office-Id': officeId },
+    signal,
+  });
+
+  if (!resp.ok) {
+    let code = 'BLUEPRINT_GET_FAILED';
+    let message = `Blueprint GET failed (${resp.status})`;
+    let correlationId: string | undefined;
+    try {
+      const parsed = await resp.json();
+      code = parsed?.error ?? parsed?.code ?? code;
+      message = parsed?.message ?? parsed?.detail?.message ?? message;
+      correlationId = parsed?.correlation_id;
+    } catch {
+      // non-JSON error body
+    }
+    throw new BlueprintsApiError(resp.status, code, message, correlationId);
+  }
+
+  return (await resp.json()) as T;
+}
+
+/** Fetch a single project's metadata + progress. */
 export async function getProject(
-  _authenticatedFetch: FetchFn,
-  _projectId: string,
-  _officeId: string,
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  signal?: AbortSignal,
 ): Promise<BlueprintProject> {
-  throw new BlueprintsApiError(
-    501,
-    'NOT_IMPLEMENTED_WAVE_6_5',
-    'getProject() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id',
+  return _getJson<BlueprintProject>(
+    authenticatedFetch,
+    `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(projectId)}`,
+    officeId,
+    signal,
   );
 }
 
-/** Wave 6.5 — list sheets for a project (with thumbnails + revision chain).
- *  Throws until backend GET endpoint lands. */
+/** List sheets for a project (with thumbnails + revision chain). */
 export async function listSheets(
-  _authenticatedFetch: FetchFn,
-  _projectId: string,
-  _officeId: string,
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  signal?: AbortSignal,
 ): Promise<BlueprintSheet[]> {
-  throw new BlueprintsApiError(
-    501,
-    'NOT_IMPLEMENTED_WAVE_6_5',
-    'listSheets() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id/sheets',
+  return _getJson<BlueprintSheet[]>(
+    authenticatedFetch,
+    `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(projectId)}/sheets`,
+    officeId,
+    signal,
   );
 }
 
-/** Wave 6.5 — poll project pipeline stage progress.
- *  Throws until backend GET endpoint lands. */
+/** Poll project pipeline stage progress. */
 export async function getProjectStatus(
-  _authenticatedFetch: FetchFn,
-  _projectId: string,
-  _officeId: string,
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  signal?: AbortSignal,
 ): Promise<{ stage_progress: StageProgress }> {
-  throw new BlueprintsApiError(
-    501,
-    'NOT_IMPLEMENTED_WAVE_6_5',
-    'getProjectStatus() lands in Wave 6.5 alongside backend GET /v1/blueprints/projects/:id/status',
+  return _getJson<{ stage_progress: StageProgress }>(
+    authenticatedFetch,
+    `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(projectId)}/status`,
+    officeId,
+    signal,
   );
+}
+
+/** Wave 7 — fetch the phased story narrative (REASON output). */
+export async function getStory(
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  signal?: AbortSignal,
+): Promise<BlueprintStory> {
+  return _getJson<BlueprintStory>(
+    authenticatedFetch,
+    `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(projectId)}/story`,
+    officeId,
+    signal,
+  );
+}
+
+/** Wave 7 — fetch project assemblies. */
+export async function getAssemblies(
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  options: GetAssembliesOptions = {},
+  signal?: AbortSignal,
+): Promise<BlueprintAssembly[]> {
+  const params = new URLSearchParams();
+  if (options.activeOnly) params.set('active_only', 'true');
+  const qs = params.toString();
+  const url = `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(
+    projectId,
+  )}/assemblies${qs ? `?${qs}` : ''}`;
+  return _getJson<BlueprintAssembly[]>(authenticatedFetch, url, officeId, signal);
+}
+
+/** Wave 7 — fetch project materials. */
+export async function getMaterials(
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  options: GetMaterialsOptions = {},
+  signal?: AbortSignal,
+): Promise<BlueprintMaterial[]> {
+  const params = new URLSearchParams();
+  if (options.tariffOnly) params.set('tariff_only', 'true');
+  if (options.hasSupplier) params.set('has_supplier', 'true');
+  const qs = params.toString();
+  const url = `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(
+    projectId,
+  )}/materials${qs ? `?${qs}` : ''}`;
+  return _getJson<BlueprintMaterial[]>(authenticatedFetch, url, officeId, signal);
+}
+
+/** Wave 7 — fetch project missing inputs. */
+export async function getMissingInputs(
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  officeId: string,
+  options: GetMissingInputsOptions = {},
+  signal?: AbortSignal,
+): Promise<BlueprintMissingInput[]> {
+  const params = new URLSearchParams();
+  if (options.unresolvedOnly) params.set('unresolved_only', 'true');
+  const qs = params.toString();
+  const url = `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(
+    projectId,
+  )}/missing_inputs${qs ? `?${qs}` : ''}`;
+  return _getJson<BlueprintMissingInput[]>(authenticatedFetch, url, officeId, signal);
+}
+
+/** Wave 7 — confirm a missing input with a field-collected value (YELLOW tier).
+ *
+ *  Server-side proxy (Wave 2.7):
+ *    1) Validates JWT.
+ *    2) Mints capability token (scope=`blueprints:resolve_missing_input`).
+ *    3) Forwards to Drew with task=RESOLVE_MISSING_INPUT.
+ *    4) Writes blueprint_receipt (Law #2) + returns the updated row. */
+export async function resolveMissingInput(
+  authenticatedFetch: FetchFn,
+  projectId: string,
+  inputId: string,
+  value: string,
+  officeId: string,
+  signal?: AbortSignal,
+): Promise<BlueprintMissingInput> {
+  const url = `${API_BASE}/api/v1/blueprints/projects/${encodeURIComponent(
+    projectId,
+  )}/missing_inputs/${encodeURIComponent(inputId)}/resolve`;
+
+  const resp = await authenticatedFetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Office-Id': officeId,
+    },
+    body: JSON.stringify({ value }),
+    signal,
+  });
+
+  if (!resp.ok) {
+    let code = 'RESOLVE_MISSING_INPUT_FAILED';
+    let message = `Resolve missing input failed (${resp.status})`;
+    let correlationId: string | undefined;
+    try {
+      const parsed = await resp.json();
+      code = parsed?.error ?? parsed?.code ?? code;
+      message = parsed?.message ?? parsed?.detail?.message ?? message;
+      correlationId = parsed?.correlation_id;
+    } catch {
+      // non-JSON error body
+    }
+    throw new BlueprintsApiError(resp.status, code, message, correlationId);
+  }
+
+  return (await resp.json()) as BlueprintMissingInput;
 }


### PR DESCRIPTION
## 1) Objective

Implement Wave 7 of the Blueprint Story Engine — the Scope tab where contractors read Drew's plain-English story of the plan set, see what's in vs out of base scope, resolve missing inputs in the field, mark alternates, and review tariff exposure.

This is THE tab where the mission rule applies hardest: complicated blueprints become a 90-second readable narrative.

## 2) Facts

Built on `dev/blueprint-engine` HEAD (`7bb64a7`, the Wave 6A merge). Reused the Wave 6A shared shells without modification:
- `CanvasCardSwitcher` (canvas card slot with 200ms cross-fade)
- `BottomChipStrip` (chip selector strip)
- `ContextTabPayload` (Tim Rail Context tab sections host)
- `blueprintUploadStore` (project_id flows through `useBlueprintUploadSnapshot`)

Wave 2.5 + 2.7 backend endpoints are NOT yet deployed in `dev/blueprint-engine`. Per the plan's fallback contract, the API client hits the documented paths; the hooks catch `BlueprintsApiError.status === 404` and degrade to an empty render path. A "Story rendering requires Wave 2.7 backend reads (PR pending merge)" banner is shown so localhost behavior is honest.

## 3) Decision

Premium reading-first UX. Story is the default chip. StoryPanel renders phased markdown with inline `TruthBadge` chips (observed / derived / assumed / missing / field_confirmed / vendor_confirmed / permit_confirmed). Assumed facts get an inline "Confirm in field" affordance that jumps to the Missing Inputs chip.

Confirm-in-Field is YELLOW tier: capability-token round-trip server-side via `POST /api/v1/blueprints/projects/:id/missing_inputs/:input_id/resolve`. Wave 2.7 mints `scope=blueprints:resolve_missing_input` and writes a `blueprint_receipt` (Law #2).

`TimRailContextTab` modification is purely **additive** — new `isScopeTab` boolean + conditional mount AFTER the existing Plans & Photos block. Zero edits to other tabs' blocks (coordinates cleanly with the Wave 8 Takeoff agent's parallel branch).

## 4) Changes

**New components (`components/service-hub/estimate-studio/scope/`):**
- `ScopeTab.tsx` — orchestrator: breadcrumb + Wave 2.7 banner + canvas + 6 chips
- `StoryPanel.tsx` — phased markdown narrative with inline TruthBadges
- `IncludedWorkCard.tsx` — assemblies with `in_base_scope=true`
- `NotInBaseCard.tsx` — assemblies excluded from base
- `MissingInputsList.tsx` — open + resolved sub-sections
- `MissingInputCard.tsx` — YELLOW-tier "Confirm in Field" form per row
- `AlternatesCard.tsx` — owner-choice swaps with Include / Exclude buttons
- `TariffExposureCard.tsx` — Section 232 / softwood lumber bucketed roll-up
- `AssemblyRow.tsx` — shared flat-card row primitive
- `TruthBadge.tsx` — 7-variant color-coded confidence chip

**New hooks:**
- `hooks/useBlueprintStory.ts` — parallel-fetch story+assemblies+materials+missing_inputs; 2s poll while REASON is `in_progress`; `backendDeployed` flag falls to `false` when all four endpoints 404.
- `hooks/useBlueprintActions.ts` — `confirmMissingInput` (real POST), `markAlternate` + `requestRFI` (UI-wired stubs with explicit NOT_IMPLEMENTED messages).

**API client (`lib/api/blueprintsApi.ts`):**
- Flipped Wave 6.5 stubs (`getProject`, `listSheets`, `getProjectStatus`) to real GETs.
- Added Wave 7 reads: `getStory`, `getAssemblies` (`activeOnly?`), `getMaterials` (`tariffOnly?`, `hasSupplier?`), `getMissingInputs` (`unresolvedOnly?`).
- Added `resolveMissingInput` POST (YELLOW tier).
- New types: `TruthClass`, `BlueprintStory`, `BlueprintStoryPhase`, `BlueprintStoryFact`, `BlueprintAssembly`, `BlueprintMaterial`, `BlueprintMissingInput`, plus option shapes.

**Tim Rail Context payload:**
- `tim-rail/ScopeContextPayload.tsx` — 6 sections (pipeline / story confidence / truth distribution bar / missing inputs count / linked destinations Materials-Takeoff-Estimate / tariff exposure summary).
- `tim-rail/TimRailContextTab.tsx` — additive: new `isScopeTab` boolean + conditional `<ScopeContextPayload />` mount AFTER `PlansPhotosContextPayload`. Property facts continue to render below via the shared `PropertySummaryCard` (matches Plans & Photos pattern).

**Route wiring:**
- `app/service-hub/estimate-studio/scope.tsx` now delegates to `<ScopeTab />` (was a TabPlaceholder).

**Tests:**
- `__tests__/scope/scope-tab.test.tsx` — 14 assertions: empty state CTA, default chip = Story, chip switching swaps canvas, Confirm flow calls `resolveMissingInput` and flips to resolved state, Wave 2.7 banner shows on 404, TruthBadge variant rendering + confidence display.
- `__tests__/visuals/regression-lock.test.ts` — Lock #17 added (5 assertions): shared-shell usage, inline TruthBadges, literal empty-state copy "Drop a plan set in Plans & Photos", `<ScopeTab />` route delegation (no TabPlaceholder).

## 5) Verification

```
$ npx tsc --noEmit  (filtered to Wave 7 files)
components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx(63,7):
  error TS2769: Property 'dataSet' does not exist on type ScrollViewProps.
  → CONFIRMED pre-existing on baseline dev/blueprint-engine (line 60 there);
    same error survives `git stash` of my changes. Not a Wave 7 regression.

Zero NEW TypeScript errors introduced.
```

```
$ npx jest __tests__/scope --no-coverage
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

```
$ npx jest __tests__/visuals/regression-lock.test.ts -t "Lock #1[3-7]" --no-coverage
Tests:       32 skipped, 21 passed, 53 total
  Lock #13 (4) ✓  Lock #14 (2) ✓  Lock #15 (5) ✓
  Lock #16 (5) ✓  Lock #17 (5) ✓

(Full file: 52/53 pass. Pre-existing Lock #2 failure — Street View zoom: 3
 not 2 — survives `git stash` of my changes; unrelated to Wave 7.)
```

## 6) Risks & Next Steps

**Risks:**
- Wave 2.7 backend reads not yet merged. The 404 path is covered by a unit test and a visible banner, so localhost behavior is honest — but no end-to-end smoke against real Drew output is possible until Wave 2.7 ships.
- The `dataSet` pre-existing tsc error in TimRailContextTab is unrelated to Wave 7 but reduces the signal-to-noise of `npx tsc --noEmit` for downstream reviewers. Worth fixing in a separate PR.
- Tim Rail Context payload depends on `useBlueprintUploadSnapshot()` for `project_id` — same module-store pattern as Wave 6A. If the Wave 8 Takeoff agent introduces a different project-id source (e.g. a route param), we'll want to converge on one path.

**Manual smoke checklist (Tonio on localhost):**
- [ ] Land on `/service-hub/estimate-studio/scope` with NO upload → empty state with "Drop a plan set in Plans & Photos" + CTA navigates correctly.
- [ ] Upload a plan set on `/plans-photos` → switch to `/scope` → Wave 2.7 banner appears (backend not deployed yet).
- [ ] When Wave 2.7 ships: Story chip default, chip switching cross-fades cleanly (200ms), MissingInputCard → Confirm in Field → success flips to green field_confirmed badge.
- [ ] Tim Rail Context tab on `/scope` shows pipeline status, confidence %, truth distribution bar, linked destinations (Materials / Takeoff / Estimate), tariff exposure summary, and the PropertySummaryCard below.
- [ ] Tablet (768px) / laptop (1280px) / desktop (1440px) / wide (1920px) — CanvasCardSwitcher card geometry stays consistent; reading column caps at 720px on wide.

**Coordination note:** The Wave 8 Takeoff agent on `feat/wave-8-takeoff` will modify `TimRailContextTab.tsx` to add a `pathname.endsWith('/takeoff')` block. This Wave 7 change uses the same additive pattern; expected conflict on that file is benign (orchestrator to rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
