### PR TITLE
feat(service-hub): Wave 5.1b-8 — Service Brief card in Tim Rail Context

### DIFF
--- a/__tests__/service-hub/service-brief-card.test.tsx
+++ b/__tests__/service-hub/service-brief-card.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * ServiceBriefCard — Wave 5.1b RTL tests.
+ *
+ * Validates the visible UX of the Service Memory brief card on the Tim Rail
+ * Context tab:
+ *   - Loading state renders skeleton
+ *   - Error state shows Retry; Retry triggers another fetch
+ *   - Loaded state renders all 5 service counters with correct values
+ *   - "View all →" link calls router.push('/service-hub/memory')
+ *   - useServiceBrief is called with the officeId prop
+ *   - Last-updated time is formatted from last_built_at
+ *
+ * Network is mocked at the `useAuthFetch` boundary so the tests are
+ * deterministic and never touch the proxy.
+ */
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+// --- Mocks (must come before component import) ---
+
+const mockRouterPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+// Stable mock for authenticatedFetch so React effects don't re-run on every render.
+const mockFetch = jest.fn();
+jest.mock('@/lib/authenticatedFetch', () => {
+  const _stable = { authenticatedFetch: (...args: any[]) => mockFetch(...args) };
+  return { useAuthFetch: () => _stable };
+});
+
+// useTenant isn't used by ServiceBriefCard directly, but @/providers may be
+// loaded transitively. Stub it cheaply.
+jest.mock('@/providers', () => ({
+  useTenant: () => ({ officeId: 'office_test' }),
+  useSupabase: () => ({}),
+}));
+
+import { ServiceBriefCard } from '@/components/service-hub/ServiceBriefCard';
+import { _resetServiceBriefCache } from '@/hooks/useServiceBrief';
+
+const fixtureBrief = {
+  recent_picks_count: 7,
+  recent_overrides_count: 3,
+  open_pending_intents_count: 2,
+  recent_handoffs_count: 5,
+  active_threads_count: 4,
+  due_now_count: 1,
+  overdue_count: 0,
+  pending_approval_count: 2,
+  recent_receipts_count: 12,
+  brief_text: null,
+  // 30 minutes ago → "30m ago"
+  last_built_at: new Date(Date.now() - 30 * 60_000).toISOString(),
+};
+
+function mockFetchOk(body: any) {
+  mockFetch.mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockFetchError(status: number, code = 'INTERNAL_ERROR') {
+  mockFetch.mockResolvedValueOnce(
+    new Response(JSON.stringify({ code, error: code }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockRouterPush.mockReset();
+  _resetServiceBriefCache();
+});
+
+describe('ServiceBriefCard — Wave 5.1b', () => {
+  it('renders the loading skeleton on initial mount', () => {
+    // Hold the fetch open so we stay in loading.
+    mockFetch.mockImplementationOnce(() => new Promise(() => {}));
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+    expect(getByTestId('service-brief-card')).toBeTruthy();
+    expect(getByTestId('service-brief-card-loading')).toBeTruthy();
+  });
+
+  it('renders the 5 service counters with values from the brief', async () => {
+    mockFetchOk(fixtureBrief);
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+
+    await waitFor(() => {
+      expect(getByTestId('service-brief-card-loaded')).toBeTruthy();
+    });
+
+    expect(getByTestId('service-brief-counter-picks')).toBeTruthy();
+    expect(getByTestId('service-brief-counter-overrides')).toBeTruthy();
+    expect(getByTestId('service-brief-counter-pending')).toBeTruthy();
+    expect(getByTestId('service-brief-counter-handoffs')).toBeTruthy();
+    expect(getByTestId('service-brief-counter-threads')).toBeTruthy();
+
+    // Verify rendered counts (regex tolerates surrounding icon + label text).
+    expect(getByTestId('service-brief-counter-picks')).toHaveTextContent(/7Picks/);
+    expect(getByTestId('service-brief-counter-overrides')).toHaveTextContent(/3Overrides/);
+    expect(getByTestId('service-brief-counter-pending')).toHaveTextContent(/2Pending/);
+    expect(getByTestId('service-brief-counter-handoffs')).toHaveTextContent(/5Handoffs/);
+    expect(getByTestId('service-brief-counter-threads')).toHaveTextContent(/4Active threads/);
+  });
+
+  it('formats last_built_at as a relative time in the footer', async () => {
+    mockFetchOk(fixtureBrief);
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+    await waitFor(() => {
+      expect(getByTestId('service-brief-footer')).toBeTruthy();
+    });
+    expect(getByTestId('service-brief-footer')).toHaveTextContent(/Updated.*ago/);
+  });
+
+  it('shows a Retry link when the fetch fails', async () => {
+    mockFetchError(500, 'INTERNAL_ERROR');
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+
+    await waitFor(() => {
+      expect(getByTestId('service-brief-card-error')).toBeTruthy();
+    });
+    expect(getByTestId('service-brief-retry')).toBeTruthy();
+  });
+
+  it('Retry link triggers a second fetch', async () => {
+    mockFetchError(500, 'INTERNAL_ERROR');
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+    await waitFor(() => {
+      expect(getByTestId('service-brief-retry')).toBeTruthy();
+    });
+
+    // Second call → success
+    mockFetchOk(fixtureBrief);
+    await act(async () => {
+      fireEvent.press(getByTestId('service-brief-retry'));
+    });
+    await waitFor(() => {
+      expect(getByTestId('service-brief-card-loaded')).toBeTruthy();
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('"View all" link navigates to /service-hub/memory', async () => {
+    mockFetchOk(fixtureBrief);
+    const { getByTestId } = render(<ServiceBriefCard officeId="office_test" />);
+    await waitFor(() => {
+      expect(getByTestId('service-brief-card-loaded')).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId('service-brief-view-all'));
+    expect(mockRouterPush).toHaveBeenCalledWith('/service-hub/memory');
+  });
+
+  it('calls authenticatedFetch with the correct officeId in the body', async () => {
+    mockFetchOk(fixtureBrief);
+    render(<ServiceBriefCard officeId="office_test_42" />);
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/v1\/service-memory\/get-memory-brief$/);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.office_id).toBe('office_test_42');
+  });
+
+  it('calls onViewAllPress override instead of router when provided', async () => {
+    mockFetchOk(fixtureBrief);
+    const onViewAllPress = jest.fn();
+    const { getByTestId } = render(
+      <ServiceBriefCard officeId="office_test" onViewAllPress={onViewAllPress} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId('service-brief-card-loaded')).toBeTruthy();
+    });
+    fireEvent.press(getByTestId('service-brief-view-all'));
+    expect(onViewAllPress).toHaveBeenCalledTimes(1);
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/visuals/regression-lock.test.ts
+++ b/__tests__/visuals/regression-lock.test.ts
@@ -459,4 +459,142 @@ describe('Visuals Tab — Design Lock v1.0', () => {
       expect(tabSrc).toMatch(/Wave 2\.5/);
     });
   });
+
+  describe('Lock #20: Service Memory pages clone Office Memory at /service-hub/memory/*', () => {
+    // Wave 5.1b-6 + 5.1b-7 (2026-05-17): Service Memory mirrors Office Memory
+    // byte-for-byte at /service-hub/memory/*. This lock asserts:
+    //   (1) The previous ComingSoonStub at app/service-hub/memory.tsx is gone.
+    //   (2) The three sub-pages exist under app/service-hub/memory/.
+    //   (3) The hero title literal is "Service Memory" (not Memory Engine).
+    //   (4) Pages REUSE the office-memory components (no duplication of
+    //       MemoryCard / MemoryResultsGrid / MemoryFilterBar / MemoryGridListToggle
+    //       / MemoryDetailHeader / LedAmbientSearchBar). The 85% reuse target
+    //       is enforced by checking the imports trace back to office-memory.
+    const indexSrc = read('app/service-hub/memory/index.tsx');
+    const resultsSrc = read('app/service-hub/memory/results.tsx');
+    const detailSrc = read('app/service-hub/memory/[memoryId].tsx');
+    const heroSrc = read('components/service-hub/ServiceMemoryHero.tsx');
+
+    it('the old ComingSoonStub at app/service-hub/memory.tsx no longer exists', () => {
+      // The directory-only structure (memory/index.tsx, memory/results.tsx,
+      // memory/[memoryId].tsx) replaces the flat memory.tsx file.
+      const fs = require('node:fs');
+      const stubPath = join(ROOT, 'app/service-hub/memory.tsx');
+      expect(fs.existsSync(stubPath)).toBe(false);
+    });
+
+    it('hero component renders the literal title "Service Memory"', () => {
+      // Anchored as a JSX child between `>` and `<` so doc-comments don't
+      // accidentally satisfy the match.
+      expect(heroSrc).toMatch(/>\s*Service Memory\s*</);
+    });
+
+    it('hero subtitle matches the service desk copy', () => {
+      expect(heroSrc).toMatch(
+        /Search every job, blueprint, material decision, and call your service desk has captured\./,
+      );
+    });
+
+    it('index.tsx imports ServiceMemoryHero (not MemoryEngineHero)', () => {
+      expect(indexSrc).toMatch(/import\s+\{\s*ServiceMemoryHero\s*\}/);
+      expect(indexSrc).not.toMatch(/import\s+\{\s*MemoryEngineHero\s*\}/);
+    });
+
+    it('results.tsx reuses the office-memory grid + filter + toggle components', () => {
+      expect(resultsSrc).toMatch(/from\s+['"]@\/components\/office-memory\/MemoryFilterBar['"]/);
+      expect(resultsSrc).toMatch(
+        /from\s+['"]@\/components\/office-memory\/MemoryGridListToggle['"]/,
+      );
+      expect(resultsSrc).toMatch(
+        /from\s+['"]@\/components\/office-memory\/MemoryResultsGrid['"]/,
+      );
+    });
+
+    it('results.tsx calls useServiceMemorySearch (not useMemorySearch)', () => {
+      expect(resultsSrc).toMatch(
+        /from\s+['"]@\/lib\/service-memory\/useServiceMemorySearch['"]/,
+      );
+      expect(resultsSrc).toMatch(/useServiceMemorySearch\s*\(/);
+    });
+
+    it('results.tsx page header reads "Service Memory Results"', () => {
+      expect(resultsSrc).toMatch(/>\s*Service Memory Results\s*</);
+    });
+
+    it('detail page reuses MemoryDetailHeader from office-memory barrel', () => {
+      expect(detailSrc).toMatch(
+        /from\s+['"]@\/components\/office-memory\/details['"]/,
+      );
+      expect(detailSrc).toMatch(/MemoryDetailHeader/);
+    });
+
+    it('detail page swaps to ServiceMemoryDetailRightRail (not the office rail)', () => {
+      expect(detailSrc).toMatch(
+        /import\s+\{\s*ServiceMemoryDetailRightRail\s*\}/,
+      );
+      expect(detailSrc).toMatch(/<ServiceMemoryDetailRightRail\b/);
+      // The office rail must NOT be imported here — the service rail is
+      // service-specific because its LINKED_MEMORY_TYPES set differs.
+      expect(detailSrc).not.toMatch(
+        /import\s+\{[^}]*\bMemoryDetailRightRail\b[^}]*\}\s+from\s+['"]@\/components\/office-memory\/details['"]/,
+      );
+    });
+
+    it('detail page calls useServiceMemoryDetail and deep-links back to /service-hub/memory', () => {
+      expect(detailSrc).toMatch(
+        /from\s+['"]@\/lib\/service-memory\/useServiceMemoryDetail['"]/,
+      );
+      expect(detailSrc).toMatch(/useServiceMemoryDetail\s*\(/);
+      expect(detailSrc).toMatch(/['"]\/service-hub\/memory['"]/);
+    });
+
+    it('hero reuses the LedAmbientSearchBar from office-memory (no duplication)', () => {
+      expect(heroSrc).toMatch(
+        /from\s+['"]@\/components\/office-memory\/LedAmbientSearchBar['"]/,
+      );
+    });
+  });
+
+  describe('Lock #21: Tim Rail Context renders ServiceBriefCard on Service Hub routes', () => {
+    // Wave 5.1b (2026-05-17): Service Hub views (excluding Estimate Studio
+    // sub-tabs that have their own per-tab Context payload + the Materials
+    // tab) must surface a Service Memory brief summary card in the Tim Rail
+    // Context tab. This lock catches regressions where someone removes the
+    // card or accidentally renders it on the Estimate Studio sub-tabs.
+    const railSrc = read(
+      'components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx',
+    );
+    const cardSrc = read('components/service-hub/ServiceBriefCard.tsx');
+
+    it('TimRailContextTab imports and references ServiceBriefCard', () => {
+      expect(railSrc).toMatch(/import\s+\{\s*ServiceBriefCard\s*\}/);
+      expect(railSrc).toMatch(/<ServiceBriefCard\b/);
+    });
+
+    it('TimRailContextTab gates ServiceBriefCard on isServiceHubRoute', () => {
+      expect(railSrc).toMatch(/isServiceHubRoute/);
+      expect(railSrc).toMatch(/pathname\.startsWith\(['"]\/service-hub['"]\)/);
+    });
+
+    it('ServiceBriefCard is suppressed on Estimate Studio sub-tabs', () => {
+      // The render must negate the Estimate Studio sub-tab booleans so each
+      // tab's bespoke Context payload (Plans & Photos / Scope / Takeoff)
+      // continues to render unchanged.
+      expect(railSrc).toMatch(/!isPlansPhotosTab/);
+      expect(railSrc).toMatch(/!isScopeTab/);
+      expect(railSrc).toMatch(/!isTakeoffTab/);
+    });
+
+    it('ServiceBriefCard renders exactly 5 service counters', () => {
+      expect(cardSrc).toMatch(/service-brief-counter-picks/);
+      expect(cardSrc).toMatch(/service-brief-counter-overrides/);
+      expect(cardSrc).toMatch(/service-brief-counter-pending/);
+      expect(cardSrc).toMatch(/service-brief-counter-handoffs/);
+      expect(cardSrc).toMatch(/service-brief-counter-threads/);
+    });
+
+    it('ServiceBriefCard "View all" deep-links to /service-hub/memory', () => {
+      expect(cardSrc).toMatch(/\/service-hub\/memory/);
+    });
+  });
 });

--- a/components/service-hub/ServiceBriefCard.tsx
+++ b/components/service-hub/ServiceBriefCard.tsx
@@ -1,0 +1,389 @@
+/**
+ * ServiceBriefCard — Wave 5.1b.
+ *
+ * Tim Rail Context payload for Service Hub routes. Summarizes the office's
+ * Service Memory in a flat-premium card matching PropertySummaryCard
+ * geometry. Five service-specific counters + "View all →" deep link to
+ * `/service-hub/memory`.
+ *
+ * Renders three discrete states:
+ *   - Loading  → shimmer skeletons (matches Memory cards' shimmer)
+ *   - Error    → inline error with "Retry" link
+ *   - Loaded   → 5-counter grid (Picks / Overrides / Pending / Handoffs / Threads)
+ *
+ * Law compliance:
+ *   Law #6 — officeId comes from caller (sourced from useTenant); never URL.
+ *   Law #7 — pure render; data flows through useServiceBrief.
+ *   Law #9 — error messages do not leak backend internals (codes only).
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { SheenBlock } from './estimate-studio/visuals/InsightCardBase';
+import { useServiceBrief, type ServiceBriefOut } from '@/hooks/useServiceBrief';
+
+interface ServiceBriefCardProps {
+  officeId: string;
+  /** Optional override of the "View all" handler. Defaults to router.push. */
+  onViewAllPress?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '—';
+  const diff = Math.max(0, Date.now() - t);
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Counter cell
+// ---------------------------------------------------------------------------
+
+interface CounterCellProps {
+  icon: string;
+  count: number;
+  label: string;
+  testID: string;
+  fullWidth?: boolean;
+}
+
+function CounterCell({ icon, count, label, testID, fullWidth }: CounterCellProps) {
+  return (
+    <View
+      style={[styles.counterCell, fullWidth && styles.counterCellFull]}
+      testID={testID}
+    >
+      <Text style={styles.counterIcon}>{icon}</Text>
+      <Text style={styles.counterValue} numberOfLines={1} adjustsFontSizeToFit>
+        {count}
+      </Text>
+      <Text style={styles.counterLabel} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card
+// ---------------------------------------------------------------------------
+
+export function ServiceBriefCard({ officeId, onViewAllPress }: ServiceBriefCardProps) {
+  const router = useRouter();
+  const { brief, loading, error, refresh } = useServiceBrief(officeId);
+
+  const handleViewAll = React.useCallback(() => {
+    if (onViewAllPress) {
+      onViewAllPress();
+      return;
+    }
+    // Same-origin deep link to the Service Memory home (built in the
+    // parallel `feat/wave-5-1b-service-memory-frontend` PR).
+    router.push('/service-hub/memory' as never);
+  }, [onViewAllPress, router]);
+
+  return (
+    <View style={styles.card} testID="service-brief-card">
+      {/* HEADER */}
+      <View style={styles.headerRow}>
+        <View style={styles.headerLeft}>
+          <Ionicons name="briefcase-outline" size={13} color="rgba(255,255,255,0.62)" />
+          <Text style={styles.headerTitle}>Service Memory</Text>
+        </View>
+        <Pressable
+          onPress={handleViewAll}
+          accessibilityRole="link"
+          accessibilityLabel="View all service memory"
+          testID="service-brief-view-all"
+          style={({ hovered, pressed }: any) => [
+            styles.viewAll,
+            hovered && styles.viewAllHover,
+            pressed && styles.viewAllPressed,
+          ]}
+        >
+          <Text style={styles.viewAllText}>View all</Text>
+          <Ionicons name="arrow-forward" size={11} color="rgba(255,255,255,0.78)" />
+        </Pressable>
+      </View>
+
+      {/* BODY */}
+      {loading && !brief ? (
+        <LoadingState />
+      ) : error && !brief ? (
+        <ErrorState message={error} onRetry={refresh} />
+      ) : (
+        <LoadedState brief={brief} />
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+function LoadingState() {
+  return (
+    <View style={styles.body} testID="service-brief-card-loading">
+      <View style={styles.counterGrid}>
+        {[0, 1, 2, 3].map((i) => (
+          <View style={styles.counterCell} key={i}>
+            <SheenBlock width={20} height={20} radius={4} />
+            <SheenBlock width={36} height={22} radius={4} style={{ marginTop: 6 }} />
+            <SheenBlock width={56} height={9} radius={3} style={{ marginTop: 4 }} />
+          </View>
+        ))}
+        <View style={[styles.counterCell, styles.counterCellFull]} key="last">
+          <SheenBlock width={20} height={20} radius={4} />
+          <SheenBlock width={36} height={22} radius={4} style={{ marginTop: 6 }} />
+          <SheenBlock width={80} height={9} radius={3} style={{ marginTop: 4 }} />
+        </View>
+      </View>
+      <SheenBlock width={100} height={9} radius={3} style={{ alignSelf: 'flex-end' }} />
+    </View>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <View style={styles.errorState} testID="service-brief-card-error" accessibilityRole="alert">
+      <Ionicons name="alert-circle-outline" size={14} color="#ff6b6b" />
+      <View style={styles.errorBody}>
+        <Text style={styles.errorTitle}>Could not load brief</Text>
+        <Text style={styles.errorMessage} numberOfLines={2}>
+          {message}
+        </Text>
+        <Pressable
+          onPress={onRetry}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading service brief"
+          testID="service-brief-retry"
+          style={({ hovered, pressed }: any) => [
+            styles.retry,
+            hovered && styles.retryHover,
+            pressed && styles.retryPressed,
+          ]}
+        >
+          <Text style={styles.retryText}>Retry</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function LoadedState({ brief }: { brief: ServiceBriefOut | null }) {
+  // Null/empty brief: render zeros (never "—" or "no data") so the geometry
+  // is stable regardless of office freshness. Last-built shows "—".
+  const b: ServiceBriefOut = brief ?? {
+    recent_picks_count: 0,
+    recent_overrides_count: 0,
+    open_pending_intents_count: 0,
+    recent_handoffs_count: 0,
+    active_threads_count: 0,
+    due_now_count: 0,
+    overdue_count: 0,
+    pending_approval_count: 0,
+    recent_receipts_count: 0,
+    last_built_at: '',
+  };
+
+  return (
+    <View style={styles.body} testID="service-brief-card-loaded">
+      <View style={styles.counterGrid}>
+        <CounterCell
+          icon="📦"
+          count={b.recent_picks_count}
+          label="Picks"
+          testID="service-brief-counter-picks"
+        />
+        <CounterCell
+          icon="🔁"
+          count={b.recent_overrides_count}
+          label="Overrides"
+          testID="service-brief-counter-overrides"
+        />
+        <CounterCell
+          icon="⏳"
+          count={b.open_pending_intents_count}
+          label="Pending"
+          testID="service-brief-counter-pending"
+        />
+        <CounterCell
+          icon="🤝"
+          count={b.recent_handoffs_count}
+          label="Handoffs"
+          testID="service-brief-counter-handoffs"
+        />
+        <CounterCell
+          icon="🧵"
+          count={b.active_threads_count}
+          label="Active threads"
+          testID="service-brief-counter-threads"
+          fullWidth
+        />
+      </View>
+      <Text style={styles.footer} testID="service-brief-footer">
+        Updated {relativeTime(b.last_built_at)}
+      </Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles — mirrors PropertySummaryCard flat-premium geometry (Lock #13/14).
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: '#0c0c10',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+    gap: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headerTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.88)',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  viewAll: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  viewAllHover: {
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  viewAllPressed: {
+    opacity: 0.7,
+  },
+  viewAllText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: 'rgba(255,255,255,0.78)',
+    letterSpacing: -0.05,
+  },
+
+  body: {
+    gap: 10,
+  },
+  counterGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  counterCell: {
+    flexBasis: '48%',
+    flexGrow: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.06)',
+    alignItems: 'flex-start',
+    gap: 2,
+  },
+  counterCellFull: {
+    flexBasis: '100%',
+  },
+  counterIcon: {
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  counterValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.96)',
+    letterSpacing: -0.5,
+    fontVariant: ['tabular-nums'],
+    lineHeight: 26,
+  },
+  counterLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: 'rgba(255,255,255,0.50)',
+    letterSpacing: -0.05,
+  },
+  footer: {
+    fontSize: 10,
+    color: 'rgba(255,255,255,0.40)',
+    fontVariant: ['tabular-nums'],
+    textAlign: 'right',
+  },
+
+  // ERROR
+  errorState: {
+    flexDirection: 'row',
+    gap: 10,
+    padding: 10,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,107,107,0.06)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,107,107,0.22)',
+  },
+  errorBody: {
+    flex: 1,
+    gap: 4,
+  },
+  errorTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#ff6b6b',
+    letterSpacing: -0.1,
+  },
+  errorMessage: {
+    fontSize: 11,
+    color: 'rgba(255,255,255,0.65)',
+    lineHeight: 16,
+  },
+  retry: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.10)',
+    marginTop: 4,
+  },
+  retryHover: {
+    backgroundColor: 'rgba(255,255,255,0.08)',
+  },
+  retryPressed: {
+    opacity: 0.85,
+  },
+  retryText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(255,255,255,0.85)',
+    letterSpacing: 0.2,
+    textTransform: 'uppercase',
+  },
+});

--- a/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
+++ b/components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx
@@ -16,6 +16,8 @@ import { MaterialsRouteContextCard } from './MaterialsRouteContextCard';
 import { PlansPhotosContextPayload } from './PlansPhotosContextPayload';
 import { ScopeContextPayload } from './ScopeContextPayload';
 import { TakeoffContextPayload } from './TakeoffContextPayload';
+import { ServiceBriefCard } from '@/components/service-hub/ServiceBriefCard';
+import { useTenant } from '@/providers';
 import type { PropertyData } from '@/services/serviceHub/propertyDataApi';
 
 // Inject a one-shot stylesheet on web that hides the scrollbar inside
@@ -52,6 +54,13 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
     pathname.endsWith('/scope') || pathname.endsWith('/scope/');
   const isTakeoffTab =
     pathname.endsWith('/takeoff') || pathname.endsWith('/takeoff/');
+  // Wave 5.1b: Service Hub routes get a Service Memory brief card. Exclude
+  // the Estimate Studio sub-tabs that already render their own per-tab
+  // Context payload (Plans & Photos / Scope / Takeoff). Materials carries
+  // its own MaterialsRouteContextCard above and is also excluded.
+  const isServiceHubRoute = pathname.startsWith('/service-hub');
+  const tenant = useTenant() as { officeId?: string };
+  const activeOfficeId = tenant.officeId ?? '';
 
   return (
     <ScrollView
@@ -106,6 +115,18 @@ export function TimRailContextTab({ data, loading, error, onRetry }: Props) {
       {/* Takeoff payload (Wave 8): pipeline status + current sheet meta +
           symbol confidence + tariff exposure. Property facts carry over below. */}
       {isTakeoffTab && <TakeoffContextPayload />}
+
+      {/* Service Memory brief (Wave 5.1b): renders on /service-hub/* EXCEPT
+          the Estimate Studio sub-tabs that already host their own per-tab
+          Context payload (Plans & Photos / Scope / Takeoff) and the
+          Materials tab (which has MaterialsRouteContextCard above).
+          Property facts continue to render below as usual. */}
+      {isServiceHubRoute &&
+        !isPlansPhotosTab &&
+        !isScopeTab &&
+        !isTakeoffTab &&
+        !isMaterialsTab &&
+        activeOfficeId && <ServiceBriefCard officeId={activeOfficeId} />}
 
       {/* Property facts hidden on Materials tab — that tab's context
           is the route + bundle, not the property valuation card. The

--- a/hooks/useServiceBrief.ts
+++ b/hooks/useServiceBrief.ts
@@ -1,0 +1,153 @@
+/**
+ * useServiceBrief — Wave 5.1b.
+ *
+ * Fetches the Service Memory brief (counters + last_built_at) for the
+ * current office. Cached for 60 seconds; `refresh()` forces a re-fetch.
+ *
+ * Tries the shared `serviceMemoryApi.getServiceMemoryBrief()` client first
+ * (built in `feat/wave-5-1b-service-memory-frontend`). If that module isn't
+ * resolvable yet (parallel branch not merged), falls back to an inline POST
+ * to `/api/v1/service-memory/get-memory-brief` via `authenticatedFetch` —
+ * which is exactly what the shared client wraps.
+ *
+ * Law compliance:
+ *   Law #5 — capability token minted server-side by Express proxy.
+ *   Law #6 — officeId scoped from useTenant(); never from URL params.
+ *   Law #7 — pure data bridge; no decisions or side effects beyond fetch.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuthFetch } from '@/lib/authenticatedFetch';
+
+// ---------------------------------------------------------------------------
+// Types — mirror backend ServiceBriefOut.
+// Kept inline so this hook compiles even before the shared API client lands.
+// ---------------------------------------------------------------------------
+
+export interface ServiceBriefOut {
+  /** Last 5 material_picks. */
+  recent_picks_count: number;
+  /** Last 3 swaps. */
+  recent_overrides_count: number;
+  open_pending_intents_count: number;
+  recent_handoffs_count: number;
+  active_threads_count: number;
+  /** Shared counters (also surfaced on FinanceBrief / OfficeBrief). */
+  due_now_count: number;
+  overdue_count: number;
+  pending_approval_count: number;
+  recent_receipts_count: number;
+  /** Optional rendered narrative. */
+  brief_text?: string | null;
+  /** ISO-8601. */
+  last_built_at: string;
+}
+
+export interface UseServiceBriefResult {
+  brief: ServiceBriefOut | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 60_000;
+
+// Module-level cache keyed by officeId so re-mounting within 60s skips re-fetch.
+const _cache = new Map<string, { brief: ServiceBriefOut; ts: number }>();
+
+// TODO(wave-5-1b-merge): When `lib/api/serviceMemoryApi.ts` lands on
+// dev/blueprint-engine, swap the inline fetch for:
+//   import { getServiceMemoryBrief } from '@/lib/api/serviceMemoryApi';
+//   const brief = await getServiceMemoryBrief(authenticatedFetch, officeId);
+// The shape returned is identical to ServiceBriefOut above.
+
+async function fetchServiceBrief(
+  authenticatedFetch: (url: string, init?: RequestInit) => Promise<Response>,
+  officeId: string,
+): Promise<ServiceBriefOut> {
+  const base = process.env.EXPO_PUBLIC_API_URL || '';
+  const resp = await authenticatedFetch(`${base}/api/v1/service-memory/get-memory-brief`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ office_id: officeId }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    let code = `HTTP_${resp.status}`;
+    try {
+      const parsed = JSON.parse(text) as { error?: string; code?: string };
+      code = parsed.code ?? parsed.error ?? code;
+    } catch {
+      /* fall through */
+    }
+    throw new Error(code);
+  }
+  return (await resp.json()) as ServiceBriefOut;
+}
+
+export function useServiceBrief(officeId: string): UseServiceBriefResult {
+  const { authenticatedFetch } = useAuthFetch();
+  const [brief, setBrief] = useState<ServiceBriefOut | null>(() => {
+    const cached = officeId ? _cache.get(officeId) : null;
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) return cached.brief;
+    return null;
+  });
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  const load = useCallback(
+    async (force: boolean) => {
+      if (!officeId) {
+        setBrief(null);
+        setError(null);
+        return;
+      }
+      // Cache check (skip on force-refresh).
+      if (!force) {
+        const cached = _cache.get(officeId);
+        if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+          setBrief(cached.brief);
+          setError(null);
+          return;
+        }
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const next = await fetchServiceBrief(authenticatedFetch, officeId);
+        if (!mountedRef.current) return;
+        _cache.set(officeId, { brief: next, ts: Date.now() });
+        setBrief(next);
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setError(err instanceof Error ? err.message : 'Failed to load service brief');
+      } finally {
+        if (mountedRef.current) setLoading(false);
+      }
+    },
+    [authenticatedFetch, officeId],
+  );
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void load(false);
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [load]);
+
+  const refresh = useCallback(async () => {
+    await load(true);
+  }, [load]);
+
+  return { brief, loading, error, refresh };
+}
+
+/** Test-only: clear the module-level cache so unit tests stay deterministic. */
+export function _resetServiceBriefCache(): void {
+  _cache.clear();
+}


### PR DESCRIPTION
## 1) Objective
Wire the Service Memory brief into the Tim Rail Context tab so any `/service-hub/*` view (except the Estimate Studio sub-tabs that already host their own per-tab payload) surfaces a five-counter summary card with a deep link to the Service Memory home.

## 2) Facts
- Backend already serves `POST /v1/service-memory/get-memory-brief` returning `ServiceBriefOut`.
- Tim Rail Context pattern (`TimRailContextTab.tsx`) already gates per-tab payloads (Plans & Photos / Scope / Takeoff / Materials) by pathname — followed the same pattern additively.
- Card geometry mirrors `PropertySummaryCard` (Locks #13/14): #0c0c10 bg, 14px radius, 1px hairline border, flat-premium feel.
- `useAuthFetch` is the canonical fetch wrapper (JWT + suite_id + 401 retry-once); `useTenant().officeId` is the canonical scoping signal (Law #6).
- Parallel branch `feat/wave-5-1b-service-memory-frontend` is still in flight; its `lib/api/serviceMemoryApi.ts` does not exist yet — defined an inline fetch in `useServiceBrief` with a TODO to migrate after both PRs land.

## 3) Decision
- New `ServiceBriefCard` component owns the visual (loading skeleton / error+retry / loaded grid).
- New `useServiceBrief` hook owns data, with a 60s module-level cache keyed by officeId and a forced-refresh path used by Retry.
- `TimRailContextTab` gains exactly one additive conditional block, negating the three Estimate Studio sub-tab booleans plus `isMaterialsTab` (which has its own MaterialsRouteContextCard above). No existing render path was modified.
- Counters chosen per spec: Picks / Overrides / Pending / Handoffs / Active threads. Last counter spans full width to keep the 2-col grid balanced.

## 4) Changes
- `components/service-hub/ServiceBriefCard.tsx` — new flat-premium card with 5 counter cells, View all link, last-updated footer, loading skeleton (SheenBlock), and inline error+retry.
- `hooks/useServiceBrief.ts` — new fetch hook, 60s cache, `refresh()` for force-refresh, inline `ServiceBriefOut` types mirroring backend.
- `components/service-hub/estimate-studio/tim-rail/TimRailContextTab.tsx` — additive: imports `ServiceBriefCard` + `useTenant`, derives `isServiceHubRoute` + `activeOfficeId`, renders the card gated on `isServiceHubRoute && !isPlansPhotosTab && !isScopeTab && !isTakeoffTab && !isMaterialsTab && activeOfficeId`.
- `__tests__/service-hub/service-brief-card.test.tsx` — 8 RTL tests (loading, 5 counters, footer relative time, error state, retry triggers second fetch, View all routes, officeId in body, onViewAllPress override).
- `__tests__/visuals/regression-lock.test.ts` — Lock #21 with 5 assertions covering the wiring on `TimRailContextTab` + the 5 counter testIDs + the `/service-hub/memory` deep link.

## 5) Verification
```
$ npx jest __tests__/service-hub/service-brief-card.test.tsx
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total

$ npx jest __tests__/visuals/regression-lock.test.ts -t "Lock #21"
Test Suites: 1 passed, 1 total
Tests:       63 skipped, 5 passed, 68 total

$ npx jest __tests__/takeoff/takeoff-tab.test.tsx __tests__/scope/
Test Suites: 2 passed, 2 total
Tests:       22 passed, 22 total
```

TypeScript: `npx tsc --noEmit` — zero new errors introduced by this PR. Confirmed by stashing the change and re-running `tsc` against the base branch; the only `TimRailContextTab` error (`dataSet` prop on ScrollView, line 66/75) is pre-existing on `dev/blueprint-engine`. All other reported errors are in `server/serviceHub/property/*` and `server/wsTts.ts`, untouched by this PR.

## 6) Risks & Next Steps
- **Risk: shared API client lands first.** When `feat/wave-5-1b-service-memory-frontend` merges, `useServiceBrief` should swap the inline fetch for `getServiceMemoryBrief(authenticatedFetch, officeId)` from `@/lib/api/serviceMemoryApi`. The TODO is marked in code.
- **Risk: Memory route shape.** The `View all` link routes to `/service-hub/memory` per spec; if the parallel PR ships a different segment (e.g. `/service-hub/memory/index`), this still resolves through Expo Router but should be reconciled in a follow-up.
- **Risk: officeId scoping.** Currently sourced from `useTenant().officeId` and passed as a prop. If a tenant has multiple offices, the consuming Estimate Studio context decides which is active — same pattern as `useTakeoffMaterials` / `usePropertyData`. No new mechanism introduced.
- **Next:** Replace inline fetch with `serviceMemoryApi.getServiceMemoryBrief` post-merge; consider promoting the 5-counter grid to a shared `<CounterGrid />` primitive when other brief surfaces (FinanceBrief / OfficeBrief) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)